### PR TITLE
Replace the linear ADSR with an exponential ADSR

### DIFF
--- a/src/VoiceBoard/ADSR.h
+++ b/src/VoiceBoard/ADSR.h
@@ -33,7 +33,7 @@ public:
 
 	void	SetAttack	(float value) { m_attack = value; }
 	void	SetDecay	(float value) { m_decay = value; }
-	void	SetSustain	(float value) { m_sustain = value; if (m_state == sustain) m_value = value; }
+	void	SetSustain	(float value) { m_sustain = value; if (m_state == sustain) m_target = value; }
 	void	SetRelease	(float value) { m_release = value; }
 	
 	float * getNFData	(unsigned int frames);
@@ -60,7 +60,8 @@ private:
 	ADSRState   m_state;
 
 	float       m_value;
-	float       m_inc;
+	float       m_target;
+	double      m_tau;
 	unsigned	m_frames_left_in_state;
 };
 


### PR DESCRIPTION
The exponential ADSR is based on a single-pole low pass filter.

Note, this patch changes the sound of every preset because of the difference in ADSR type.
Exponential ADSR change smoothly, especially for the AMP ENV, whereas the linear ADSR causes AMP ENV to change abruptly (notable on presets with short release that are meant for keys; e.g. Pianola from BrianBanks1).
This behaviour is said to be similar to classic analog synths.

Unfortunately since both AMP ENV and FILTER ENV uses the same ADSR class, the FILTER ENV is also changed.
For me personally, exponential ADSR is always preferable for AMP ENV, while for FILTER ENV linear ADSR is different, but not less preferable.

Would it be better to have both? if so then there should be a way of choosing between them.
I could think of two ways of switching,
- a switch between the old linear or newer exp,
- or a knob where linear behaviour is simulated with having large overshoot and scaling.

Thoughts?
