### PR TITLE
Update FSF address

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -2,7 +2,7 @@
 		       Version 2, June 1991
 
  Copyright (C) 1989, 1991 Free Software Foundation, Inc.
-                       59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 


### PR DESCRIPTION
Hi,

I currently package amsynth for Fedora, and the package-review tool complains about the FSF address (you use the old one): "E: incorrect-fsf-address /usr/share/licenses/amsynth/COPYING ".

Here is the corrected address, based on http://www.gnu.org/licenses/gpl-2.0.txt

Thank you in advance