### PR TITLE
Allow microtonal in plugins

### DIFF
--- a/src/Synthesizer.cpp
+++ b/src/Synthesizer.cpp
@@ -46,6 +46,9 @@ Synthesizer::Synthesizer()
 	_voiceAllocationUnit->SetMaxVoices(config.polyphony);
 	_voiceAllocationUnit->setPitchBendRangeSemitones(config.pitch_bend_range);
 	
+	if (config.current_tuning_file != "default")
+		_voiceAllocationUnit->loadScale(config.current_tuning_file.c_str());
+	
 	_presetController = new PresetController;
 	_presetController->loadPresets(config.current_bank_file.c_str());
 	_presetController->selectPreset(0);


### PR DESCRIPTION
Hi

Just added few lines to allow the use of microtonal tunings in plugins (at least with dssi) through the conf file. It builds and works fine with rosegarden in Fedora 24.

I don't know if it is the better way to make it work, but it works :)