### PR TITLE
Adds EN and FR manpages

### DIFF
--- a/data/amsynth.1
+++ b/data/amsynth.1
@@ -1,0 +1,68 @@
+.TH AMSYNTH "1" "September 2016" "amsynth 1.6.4" "User Commands"
+.SH NAME
+amsynth \- a two oscillators software synthesizer.
+.SH SYNOPSIS
+.PP
+.B amsynth
+[options]
+.SH DESCRIPTION
+.PP
+amsynth 1.6.4 [Jan 19 2016]  [http://amsynth.github.io/].
+Copyright 2001\-2016 Nick Dowell <nixx@nixx.org.uk>.
+.PP
+amsynth is an easy-to-use software synth with a classic subtractive synthesizer topology.
+.PP
+amsynth comes with ABSOLUTELY NO WARRANTY.
+This is free software, and you are welcome to redistribute it
+under certain conditions. See the file COPYING for details.
+.SH OPTIONS
+.PP
+Any options given here override those in the config file ($HOME/.amSynthrc).
+.HP
+\fB\-h\fR \- show a help message
+.HP
+\fB\-v\fR \- show version information
+.HP
+\fB\-d\fR \- show some debugging output
+.HP
+\fB\-b\fR <filename> \- use <filename> as the bank to store presets
+.HP
+\fB\-t\fR <filename> \- use <filename> as a tuning file
+.HP
+\fB\-a\fR <string> \- set the sound output driver to use [alsa/oss/auto(default)]
+.HP
+\fB\-r\fR <int> \- set the sampling rate to use
+.HP
+\fB\-m\fR <string> \- set the midi driver to use [alsa/oss/auto(default)]
+.HP
+\fB\-c\fR <int> \- set the midi channel to respond to (default=all)
+.HP
+\fB\-p\fR <int> \- set the polyphony (maximum active voices)
+.HP
+\fB\-n\fR <name> \- specify the JACK client name to use
+.HP
+\fB\-\-jack_autoconnect=<true|false>
+.SH FILES
+.TP
+.B $HOME/.amSynthrc
+.PP
+Configuration for amsynth.
+.TP
+.B $HOME/.amsynth/*
+.PP
+Banks and others.
+.TP
+.B $HOME/.amSynth.presets
+.PP
+Presets.
+.SH ENVIRONMENT
+.PP
+nothing
+.SH BUGS & FEATURES REQUEST
+.PP
+If you find any bug or if you would like to propose a new feature, please report it to https://github.com/amsynth/amsynth/issues .
+.SH AUTHORS
+.PP
+Nick Dowell and contributors. See complete list at amsynth's "Help" -> "About" Dialog.
+.SH MISC
+This manual page was written by Olivier Humbert <trebmuh@tuxfamily.org> on September the 06 2016 as a part of the LibraZiK project (and can be used by others).

--- a/data/amsynth.fr.1
+++ b/data/amsynth.fr.1
@@ -1,0 +1,68 @@
+.TH AMSYNTH "1" "Septembre 2016" "amsynth 1.6.4" "Commandes utilisateur"
+.SH NOM
+amsynth \- un synthétiseur logiciel à deux oscillateurs.
+.SH SYNOPSIS
+.PP
+.B amsynth
+[options]
+.SH DESCRIPTION
+.PP
+amsynth 1.6.4 [Janv 19 2016]  [http://amsynth.github.io/].
+Copyright 2001\-2016 Nick Dowell <nixx@nixx.org.uk>.
+.PP
+amsynth est un synthétiseur logiciel facile à utiliser avec une topologie de synthétiseur soustractif classique.
+.PP
+amsynth est fourni SANS AUCUNE GARANTIE.
+C'est un logiciel libre, et vous êtes encouragé à le redistribuer sous certaines conditions.
+Voir le fichier COPYING pour les détails.
+.SH OPTIONS
+.PP
+Toute option donnée ici écrase celle du fichier de configuration ($HOME/.amSynthrc).
+.HP
+\fB\-h\fR \- affiche un message d'aide (en anglais)
+.HP
+\fB\-v\fR \- affiche les informations de version
+.HP
+\fB\-d\fR \- affiche des informations de débogage
+.HP
+\fB\-b\fR <nom_de_fichier> \- utilise <nom_de_fichier> en tant que banque pour sauvegarder les pré-réglages
+.HP
+\fB\-t\fR <nom_de_fichier> \- utilise <nom_de_fichier> en tant que fichier d'accordage
+.HP
+\fB\-a\fR <chaîne_de_caractères> \- paramètre le pilote de sortie son à utiliser [alsa/oss/auto(défaut)]
+.HP
+\fB\-r\fR <entier> \- paramètre le taux d'échantillonnage à utiliser
+.HP
+\fB\-m\fR <chaîne_de_caractères> \- paramètre le pilote MIDI à utiliser [alsa/oss/auto(défaut)]
+.HP
+\fB\-c\fR <chaîne_de_caractères> \- paramètre le canal MIDI auquel répondre (défaut=tous)
+.HP
+\fB\-p\fR <entier> \- paramètre la polyphonie (voix actives maximum)
+.HP
+\fB\-n\fR <nom> \- spécifie le nom de client JACK à utiliser
+.HP
+\fB\-\-jack_autoconnect=<true|false>
+.SH FICHIERS
+.TP
+.B $HOME/.amSynthrc
+.PP
+Configuration pour amsynth.
+.TP
+.B $HOME/.amsynth/*
+.PP
+Banques et autres.
+.TP
+.B $HOME/.amSynth.presets
+.PP
+Pré-réglages.
+.SH ENVIRONEMENT
+.PP
+nothing
+.SH BOGUES & DEMANDE DE FONCTIONNALITÉS
+.PP
+Si vous trouvez un bogue, ou si vous voulez proposer une nouvelle fonctionnalité, veuillez le reporter à https://github.com/amsynth/amsynth/issues .
+.SH AUTEURS
+.PP
+Nick Dowell et contributeurs. Voir la liste complète dans le dialogue d'amsynth : "Aide" -> "À propos".
+.SH DIVERS
+Cette page de manuel a été écrite par Olivier Humbert <trebmuh@tuxfamily.org> le 06 septembre 2016 en tant que partie du projet LibraZiK (et peut être utilisé par d'autres).


### PR DESCRIPTION
Please find man pages built from the return of `amsynth -h`. Hope you'll find them useful.

Please, have a look to https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=836878 as well. It's over my competences, but you might understand better than me what Jonas says there.

Hopes that helps