### PR TITLE
Add and install an appdata file (translatable).

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -285,6 +285,13 @@ desktopdir = $(datadir)/applications
 desktop_in_files = data/amsynth.desktop.in
 desktop_DATA = $(desktop_in_files:.desktop.in=.desktop)
 
+appdatadir = $(datadir)/appdata
+appdata_in_files = data/amsynth.appdata.xml.in
+appdata_DATA = $(appdata_in_files:.appdata.xml.in=.appdata.xml)
+@INTLTOOL_XML_RULE@
+
+EXTRA_DIST += $(appdata_in_files)
+
 skinsdefaultdir="${pkgdatadir}/skins/default"
 dist_skinsdefault_DATA = \
 	data/default-skin/background.png \

--- a/configure.ac
+++ b/configure.ac
@@ -146,6 +146,7 @@ AM_CONDITIONAL([DARWIN], [test "$(uname -s)" = "Darwin"])
 AC_OUTPUT([
     Makefile
     data/amsynth.desktop
+    data/amsynth.appdata.xml
     po/Makefile.in
 ])
 

--- a/data/amsynth.appdata.xml.in
+++ b/data/amsynth.appdata.xml.in
@@ -1,0 +1,44 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<component>
+  <id>amsynth.desktop</id>
+  <metadata_license>CC0-1.0</metadata_license>
+  <_name>Analog Modelling SYNTHesizer</_name>
+  <project_license>GPL-2.0+</project_license>
+  <_summary>Analog modelling (a.k.a virtual analog) software synthesizer</_summary>
+  <url type="homepage">http://amsynth.github.io/</url>
+  <description>
+    <_p>Amsynth is an analog modelling (a.k.a virtual analog) software synthesizer.
+It mimics the operation of early analog subtractive synthesizers with
+classic oscillator waveforms, envelopes, filter, modulation and effects.
+The aim is to make it easy to create and modify sounds.</_p>
+    <_p>Features:</_p>
+    <ul>
+      <_li>Dual oscillators (sine / saw / square / noise) with hard sync</_li>
+      <_li>12/24 dB/oct resonant filter (low-pass / high-pass / band-pass / notch)</_li>
+      <_li>Mono / poly / legato keyboard modes</_li>
+      <_li>Dual ADSR envelope generators (filter &amp; amplitude)</_li>
+      <_li>LFO which can modulate the oscillators, filter, and amplitude</_li>
+      <_li>Distortion and reverb</_li>
+      <_li>Hundreds of presets</_li>
+    </ul>
+
+    <_p>There are currently several different ways to run amsynth:</_p>
+    <ul>
+      <_li>Stand-alone application using JACK, ALSA or OSS</_li>
+      <_li>DSSI plug-in</_li>
+      <_li>LV2 plug-in</_li>
+      <_li>VST plug-in</_li>
+    </ul>
+  </description>
+  <screenshots>
+    <screenshot type="default">
+      <image height="462" width="616">http://amsynth.github.io/images/ScreenShot.png</image>
+      <caption>AMSYNTH Main Window</caption>
+    </screenshot>
+  </screenshots>
+  <provides>
+    <binary>amsynth</binary>
+  </provides>
+  <update_contact>nick_AT_nickdowell.com</update_contact>
+  <translation type="gettext">amsynth</translation>
+</component>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -7,5 +7,4 @@ src/GUI/PresetControllerView.cc
 src/GUI/presets_menu.cpp
 src/main.cc
 src/PresetController.cc
-data/amsynth.appdata.xml
 data/amsynth.appdata.xml.in

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -7,3 +7,4 @@ src/GUI/PresetControllerView.cc
 src/GUI/presets_menu.cpp
 src/main.cc
 src/PresetController.cc
+data/amsynth.appdata.xml.in

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -8,3 +8,4 @@ src/GUI/presets_menu.cpp
 src/main.cc
 src/PresetController.cc
 data/amsynth.appdata.xml
+data/amsynth.appdata.xml.in

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -7,4 +7,4 @@ src/GUI/PresetControllerView.cc
 src/GUI/presets_menu.cpp
 src/main.cc
 src/PresetController.cc
-data/amsynth.appdata.xml.in
+data/amsynth.appdata.xml

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,0 +1,1 @@
+data/amsynth.appdata.xml


### PR DESCRIPTION
Appdata files are used to generate appstream metadata which is
then used by software stores like gnome-software and plasma-discover
to display the app in its list of available apps for installation.
Basically, installing this appdata file makes your app show up
in these kind of appstream dependent appstores, thus making the
app easily discoverable, installable and reviewable.

The appdata file added here is set up to be translatable using
usual GETTEXT methods, once the appropriate strings are added to
the po files.

See the appdata specification:
https://www.freedesktop.org/software/appstream/docs/