### PR TITLE
Fix MIDI capitalization in user-visible strings

### DIFF
--- a/data/amsynth.1
+++ b/data/amsynth.1
@@ -33,9 +33,9 @@ Any options given here override those in the config file ($HOME/.amSynthrc).
 .HP
 \fB\-r\fR <int> \- set the sampling rate to use
 .HP
-\fB\-m\fR <string> \- set the midi driver to use [alsa/oss/auto(default)]
+\fB\-m\fR <string> \- set the MIDI driver to use [alsa/oss/auto(default)]
 .HP
-\fB\-c\fR <int> \- set the midi channel to respond to (default=all)
+\fB\-c\fR <int> \- set the MIDI channel to respond to (default=all)
 .HP
 \fB\-p\fR <int> \- set the polyphony (maximum active voices)
 .HP

--- a/data/rc
+++ b/data/rc
@@ -6,19 +6,19 @@
 #	MIDI Input Configuration
 #
 
-# select midi driver to use [ auto / alsa / oss ]
+# select MIDI driver to use [ auto / alsa / oss ]
 # the ALSA driver uses the sequencer client interface. you will have to
 # 'aconnect' it to something to get input.
 
 midi_driver 		auto
 
-# set the OSS compatible midi device file to read input data from.
+# set the OSS compatible MIDI device file to read input data from.
 # eg /dev/midi or /dev/midi00 for some systems.
 
 oss_midi_device		/dev/midi
 
-# midi channel to listen for events on. midi channels are numbered 1-16,
-# setting midi channel to 0 will listen on all channels
+# MIDI channel to listen for events on. MIDI channels are numbered 1-16,
+# setting MIDI channel to 0 will listen on all channels
 
 midi_channel		0
 

--- a/src/GUI/GUI.cc
+++ b/src/GUI/GUI.cc
@@ -501,7 +501,7 @@ GUI::post_init()
 		bad_config = true;
 		MessageDialog dlg (*this, _("amsynth configuration error"), false, MESSAGE_ERROR, BUTTONS_OK, true);
 		dlg.set_secondary_text(
-			_("amsynth could not initialise the selected midi device.\n\n"
+			_("amsynth could not initialise the selected MIDI device.\n\n"
 			"Please review the configuration and restart")
 		    );
 		dlg.run();

--- a/src/drivers/ALSAMidiDriver.cc
+++ b/src/drivers/ALSAMidiDriver.cc
@@ -157,7 +157,7 @@ ALSAMidiDriver::ALSAMidiDriver(const char *client_name)
 	seq_handle = NULL;
 	memset( &pollfd_in, 0, sizeof(pollfd_in) );
 	if( snd_midi_event_new( 32, &seq_midi_parser ) )
-		cout << "Error creating midi event parser\n";
+		cout << "Error creating MIDI event parser\n";
 }
 
 ALSAMidiDriver::~ALSAMidiDriver()

--- a/src/main.cc
+++ b/src/main.cc
@@ -330,8 +330,8 @@ int main( int argc, char *argv[] )
 				     << endl
 				     << _("	-a <string> set the sound output driver to use [alsa/oss/auto(default)]") << endl
 				     << _("	-r <int>    set the sampling rate to use") << endl
-				     << _("	-m <string> set the midi driver to use [alsa/oss/auto(default)]") << endl
-				     << _("	-c <int>    set the midi channel to respond to (default=all)") << endl
+				     << _("	-m <string> set the MIDI driver to use [alsa/oss/auto(default)]") << endl
+				     << _("	-c <int>    set the MIDI channel to respond to (default=all)") << endl
 				     << _("	-p <int>    set the polyphony (maximum active voices)") << endl
 				     << endl
 				     << _("	-n <name>   specify the JACK client name to use") << endl


### PR DESCRIPTION
I left the following strings as-is for now - should they also be changed? The first NEWS entry looks like an issue/pull request title though.
```
AUTHORS: - Input on the GUI - new midi controller config, motivating re-organisation of menus, shortcut keys..
AUTHORS: - Added midi out capabilities for control surfaces with feedback
NEWS:  - #26 setting midi channel from command line
NEWS:  * handle all notes off midi message
src/tests.cpp:        assert(midiOut.empty() || !"no midi output should be generated when a cc is processed");
src/tests.cpp:    assert(midiOut.size() == 1 || !"midi output should be generated when a parameter is changed");
src/tests.cpp:    assert(midiOut[0].value == 0 || !"midi output value is incorrect");
```