### PR TITLE
Preset: return reference to mName

### DIFF
--- a/src/Preset.h
+++ b/src/Preset.h
@@ -39,7 +39,7 @@ public:
 	
 	bool			isEqual			(const Preset &);
 
-	const std::string getName		() const { return mName; }
+	const std::string& getName		() const { return mName; }
 	void			setName			(const std::string name) { mName = name; }
 	
 	Parameter&		getParameter	(const std::string name);


### PR DESCRIPTION
Otherwise we get temporary objects with non deterministic lifetime. Errors
caused are e.g mangled names in dssi get_program. Not easy to debug believe
me!

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>