### PR TITLE
Fix inconsistent spelling of "analog"

### DIFF
--- a/src/GUI/GUI.cc
+++ b/src/GUI/GUI.cc
@@ -761,7 +761,7 @@ GUI::event_handler(const int e)
                               "version", version.c_str(),
                               "authors", authors,
                               "translator-credits", "Olivier Humbert - French\nGeorg Krause - German\nPeter Körner - German",
-                              "comments", _("Analogue Modelling SYNTHesizer"),
+                              "comments", _("Analog Modelling SYNTHesizer"),
                               "website", PACKAGE_URL,
                               "copyright", _("Copyright © 2002 - 2016 Nick Dowell and contributors"),
                               NULL);


### PR DESCRIPTION
The American English spelling is also used in the following places:
README file, AppData file, .desktop file, website, repository description.