### PR TITLE
Enable extraction of comments for translators and add two such comments

### DIFF
--- a/po/Makevars
+++ b/po/Makevars
@@ -8,7 +8,7 @@ subdir = po
 top_builddir = ..
 
 # These options get passed to xgettext.
-XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --from-code=utf-8
+XGETTEXT_OPTIONS = --keyword=_ --keyword=N_ --from-code=utf-8 --add-comments=@translators
 
 # This is the copyright holder that gets inserted into the header of the
 # $(DOMAIN).pot file.  Set this to the copyright holder of the surrounding

--- a/src/GUI/GUI.cc
+++ b/src/GUI/GUI.cc
@@ -349,6 +349,7 @@ GUI::create_menus	( )
 	Menu *menu_utils_keyboards = manage (new Menu());
 	MenuList& list_utils_keyboards = menu_utils_keyboards->items ();
 
+	// @translators: This is an application name and its abbreviation
 	menu_item = manage (new MenuItem(_("Virtual Keyboard (vkeybd)")));
 	menu_item->signal_activate().connect(sigc::bind(mem_fun(*this, &GUI::event_handler),(int)evVkeybd));
 	// vkeybd must exist, and we must be using ALSA MIDI
@@ -356,6 +357,7 @@ GUI::create_menus	( )
 		menu_item->set_sensitive( false );
 	list_utils_keyboards.push_back (*menu_item);
 
+	// @translators: This is an application name and its abbreviation
 	menu_item = manage (new MenuItem(_("Virtual MIDI Piano Keyboard (VMPK)")));
 	menu_item->signal_activate().connect(sigc::bind(mem_fun(*this, &GUI::command_run),"vmpk"));
 	if (command_exists("vmpk") != 0) menu_item->set_sensitive( false );


### PR DESCRIPTION
The prefix for these comments is set to `@translators`.

Example comment: `// @translators: This is a comment for translators`

As a side effect, this change also causes the removal of some leftover comments from the translation files the next time they are regenerated.