### PR TITLE
Fix generation of translated AppData file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@ Makefile.in
 missing
 po/*.gmo
 po/*.header
+po/.intltool-merge-cache
 po/boldquot.sed
 po/insert-header.sin
 po/Makefile.in

--- a/Makefile.am
+++ b/Makefile.am
@@ -292,6 +292,8 @@ appdata_DATA = $(appdata_in_files:.appdata.xml.in=.appdata.xml)
 
 EXTRA_DIST += $(appdata_in_files)
 
+DISTCLEANFILES = $(appdata_DATA)
+
 skinsdefaultdir="${pkgdatadir}/skins/default"
 dist_skinsdefault_DATA = \
 	data/skins/default/background.png \

--- a/configure.ac
+++ b/configure.ac
@@ -146,7 +146,6 @@ AM_CONDITIONAL([DARWIN], [test "$(uname -s)" = "Darwin"])
 AC_OUTPUT([
     Makefile
     data/amsynth.desktop
-    data/amsynth.appdata.xml
     po/Makefile.in
 ])
 

--- a/po/POTFILES.skip
+++ b/po/POTFILES.skip
@@ -1,1 +1,0 @@
-data/amsynth.appdata.xml


### PR DESCRIPTION
Previously, the untranslated, marked-up-for-translation AppData file simply was copied to its final location instead of being processed further.

This change removes the file from `AC_OUTPUT` - preventing the simple copying - and adds it to `DISTCLEANFILES` for cleanup. Also, `POTFILES.skip` is no longer needed according to `intltool-update --maintain`.

Documentation: [CONFIG_FILES](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Configuration-Files.html#index-AC_005fCONFIG_005fFILES-79) via [AC_OUTPUT (Obsolete Macros)](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Obsolete-Macros.html#index-AC_005fOUTPUT-2133) via [AC_OUTPUT](https://www.gnu.org/savannah-checkouts/gnu/autoconf/manual/autoconf-2.69/html_node/Output.html#index-AC_005fOUTPUT-64)

This works for me (on Linux), but needs a look from someone with more Autotools experience than I have.
