### PR TITLE
Exchange entries of saw/triangle OSC waveform label

### DIFF
--- a/data/amsynth.lv2/amsynth.ttl
+++ b/data/amsynth.lv2/amsynth.ttl
@@ -174,7 +174,7 @@
         lv2:maximum 4.000000 ;
         lv2:scalePoint [ rdf:value 0.0 ; rdfs:label "sine"] ;
         lv2:scalePoint [ rdf:value 1.0 ; rdfs:label "square / pulse" ] ;
-        lv2:scalePoint [ rdf:value 2.0 ; rdfs:label "saw / triangle" ] ;
+        lv2:scalePoint [ rdf:value 2.0 ; rdfs:label "triangle / saw" ] ;
         lv2:scalePoint [ rdf:value 3.0 ; rdfs:label "white noise" ] ;
         lv2:scalePoint [ rdf:value 4.0 ; rdfs:label "noise + sample & hold" ] ;
         pg:group <http://code.google.com/p/amsynth/amsynth#group_osc1> ;
@@ -286,7 +286,7 @@
         lv2:maximum 4.000000 ;
         lv2:scalePoint [ rdf:value 0.0 ; rdfs:label "sine"] ;
         lv2:scalePoint [ rdf:value 1.0 ; rdfs:label "square / pulse" ] ;
-        lv2:scalePoint [ rdf:value 2.0 ; rdfs:label "saw / triangle" ] ;
+        lv2:scalePoint [ rdf:value 2.0 ; rdfs:label "triangle / saw" ] ;
         lv2:scalePoint [ rdf:value 3.0 ; rdfs:label "white noise" ] ;
         lv2:scalePoint [ rdf:value 4.0 ; rdfs:label "noise + sample & hold" ] ;
         pg:group <http://code.google.com/p/amsynth/amsynth#group_osc2> ;

--- a/src/Preset.cc
+++ b/src/Preset.cc
@@ -41,7 +41,7 @@ Parameter TimeParameter (const std::string name, Param id)
 }
 
 const char *osc_waveform_names[] = {
-	"sine", "square / pulse", "saw / triangle", "white noise", "noise + sample & hold", NULL
+	"sine", "square / pulse", "triangle / saw", "white noise", "noise + sample & hold", NULL
 };
 
 const char *lfo_waveform_names[] = {


### PR DESCRIPTION
Now, the first/left waveform listed (triangle) corresponds to the shape knob turned left (triangle wave) and the second/right one (saw) to the shape knob turned right (sawtooth wave).

I checked the waveforms corresponding to left/right knob positions using glfer.

Are the .ttl adjustments OK?
