### PR TITLE
Improve man pages

### DIFF
--- a/data/amsynth.1.md
+++ b/data/amsynth.1.md
@@ -1,11 +1,11 @@
 % AMSYNTH(1) amsynth VERSION | User Commands
 %
-% September 2016
+% January 2017
 
 NAME
 ====
 
-amsynth - a two oscillators software synthesizer.
+amsynth - a two oscillator subtractive software synthesizer
 
 SYNOPSIS
 ========
@@ -15,19 +15,12 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-amsynth VERSION \[Jan 19 2016\]  \[http://amsynth.github.io/\].
-Copyright 2001-2017 Nick Dowell <nick@nickdowell.com>.
-
 amsynth is an easy-to-use software synth with a classic subtractive synthesizer topology.
-
-amsynth comes with ABSOLUTELY NO WARRANTY.
-This is free software, and you are welcome to redistribute it
-under certain conditions. See the file COPYING for details.
 
 OPTIONS
 =======
 
-Any options given here override those in the config file (\$HOME/.amSynthrc).
+The following options override those in the config file (\$HOME/.amSynthrc).
 
 `-h`
 
@@ -41,13 +34,13 @@ Any options given here override those in the config file (\$HOME/.amSynthrc).
 
 :   run in headless mode (without GUI)
 
-`-b` \<filename\>
+`-b` \<file\>
 
-:   use \<filename\> as the bank to store presets
+:   use \<file\> as the bank to store presets
 
-`-t` \<filename\>
+`-t` \<file\>
 
-:   use \<filename\> as a tuning file
+:   use \<file\> as a tuning file
 
 `-a` \<string\>
 
@@ -80,34 +73,37 @@ Any options given here override those in the config file (\$HOME/.amSynthrc).
 FILES
 =====
 
-**\$HOME/.amSynthrc**
+`$HOME/.amSynthrc`
 
-Configuration for amsynth.
+:   Configuration for amsynth.
 
-**\$HOME/.amsynth/\***
+`$HOME/.amsynth/*`
 
-Banks and others.
+:   Banks and others.
 
-**\$HOME/.amSynth.presets**
+`$HOME/.amSynth.presets`
 
-Presets.
+:   Presets.
 
 ENVIRONMENT
 ===========
 
-nothing
+`AMSYNTH_NO_GUI`
 
-BUGS & FEATURES REQUEST
+:   If AMSYNTH\_NO\_GUI is set, amsynth is started in headless mode (without GUI).
+
+`AMSYNTH_SKIN`
+
+:   Specifies the directory from which amsynth should load its skin.
+
+BUGS & FEATURE REQUESTS
 =======================
 
-If you find any bug or if you would like to propose a new feature, please report it to https://github.com/amsynth/amsynth/issues .
+If you find a bug or if you would like to propose a new feature, please report it at https://github.com/amsynth/amsynth/issues .
 
 AUTHORS
 =======
 
-Nick Dowell and contributors. See complete list at amsynth's "Help" -> "About" Dialog.
+Nick Dowell and contributors. See complete list in amsynth's "Help" -> "About" dialog.
 
-MISC
-====
-
-This manual page was written by Olivier Humbert <trebmuh@tuxfamily.org> on September the 06 2016 as a part of the LibraZiK project (and can be used by others).
+The initial version of this manual page was written by Olivier Humbert <trebmuh@tuxfamily.org> on September 06, 2016 as a part of the LibraZiK project (and can be used by others).

--- a/data/amsynth.fr.1.md
+++ b/data/amsynth.fr.1.md
@@ -1,11 +1,11 @@
 % AMSYNTH(1) amsynth VERSION | Commandes utilisateur
 %
-% Septembre 2016
+% Janvier 2017
 
 NOM
 ===
 
-amsynth - un synthétiseur logiciel à deux oscillateurs.
+amsynth - un synthétiseur logiciel soustractif à deux oscillateurs
 
 SYNOPSIS
 ========
@@ -15,23 +15,16 @@ SYNOPSIS
 DESCRIPTION
 ===========
 
-amsynth VERSION \[Janv 19 2016\]  \[http://amsynth.github.io/\].
-Copyright 2001-2017 Nick Dowell <nick@nickdowell.com>.
-
 amsynth est un synthétiseur logiciel facile à utiliser avec une topologie de synthétiseur soustractif classique.
-
-amsynth est fourni SANS AUCUNE GARANTIE.
-C'est un logiciel libre, et vous êtes encouragé à le redistribuer sous certaines conditions.
-Voir le fichier COPYING pour les détails.
 
 OPTIONS
 =======
 
-Toute option donnée ici écrase celle du fichier de configuration (\$HOME/.amSynthrc).
+Les options suivantes écrase celle du fichier de configuration (\$HOME/.amSynthrc).
 
 `-h`
 
-:   affiche un message d'aide (en anglais)
+:   affiche un message d'aide
 
 `-v`
 
@@ -61,7 +54,7 @@ Toute option donnée ici écrase celle du fichier de configuration (\$HOME/.amSy
 
 :   paramètre le pilote MIDI à utiliser \[alsa/oss/auto(défaut)\]
 
-`-c` \<chaîne\_de\_caractères\>
+`-c` \<entier\>
 
 :   paramètre le canal MIDI auquel répondre (défaut=tous)
 
@@ -80,22 +73,28 @@ Toute option donnée ici écrase celle du fichier de configuration (\$HOME/.amSy
 FICHIERS
 ========
 
-**\$HOME/.amSynthrc**
+`$HOME/.amSynthrc`
 
-Configuration pour amsynth.
+:   Configuration pour amsynth.
 
-**\$HOME/.amsynth/\***
+`$HOME/.amsynth/*`
 
-Banques et autres.
+:   Banques et autres.
 
-**\$HOME/.amSynth.presets**
+`$HOME/.amSynth.presets`
 
-Pré-réglages.
+:   Pré-réglages.
 
-ENVIRONEMENT
-============
+ENVIRONNEMENT
+=============
 
-nothing
+`AMSYNTH_NO_GUI`
+
+:   If AMSYNTH\_NO\_GUI is set, amsynth is started in headless mode (without GUI).
+
+`AMSYNTH_SKIN`
+
+:   Specifies the directory from which amsynth should load its skin.
 
 BOGUES & DEMANDE DE FONCTIONNALITÉS
 ===================================
@@ -107,7 +106,4 @@ AUTEURS
 
 Nick Dowell et contributeurs. Voir la liste complète dans le dialogue d'amsynth : "Aide" -> "À propos".
 
-DIVERS
-======
-
-Cette page de manuel a été écrite par Olivier Humbert <trebmuh@tuxfamily.org> le 06 septembre 2016 en tant que partie du projet LibraZiK (et peut être utilisé par d'autres).
+La version initiale de cette page de manuel a été écrite par Olivier Humbert <trebmuh@tuxfamily.org> le 06 septembre 2016 en tant que partie du projet LibraZiK (et peut être utilisé par d'autres).


### PR DESCRIPTION
The `NAME` section changes are based on the .desktop file's `Comment` entries, the `ENVIRONMENT` additions on 490c0e8 and the skinning `README`.

@trebmuh: Are these changes OK? Please check my French translations in particular as well as the adjusted author information. The latter is not optimal, but I hope it's acceptable this way (suggestions welcome). Also, the French man page still contains some untranslated strings.
