### PR TITLE
Fix inconsistencies and typos in user-visible strings

### DIFF
--- a/data/lv2-amsynth-plugin.metainfo.xml.in
+++ b/data/lv2-amsynth-plugin.metainfo.xml.in
@@ -2,7 +2,7 @@
 <component type="addon">
   <id>lv2-amsynth-plugin</id>
   <extends>amsynth.desktop</extends>
-  <_name>lv2 plugin</_name>
+  <_name>LV2 plugin</_name>
   <_summary>Plugin for the LV2 audio standard</_summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>

--- a/data/vst-amsynth-plugin.metainfo.xml.in
+++ b/data/vst-amsynth-plugin.metainfo.xml.in
@@ -3,7 +3,7 @@
   <id>vst-amsynth-plugin</id>
   <extends>amsynth.desktop</extends>
   <_name>VST plugin</_name>
-  <_summary>Amsynth plugin for the VST protocol</_summary>
+  <_summary>Plugin for the VST protocol</_summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <translation type="gettext">amsynth</translation>

--- a/src/GUI/MainMenu.cpp
+++ b/src/GUI/MainMenu.cpp
@@ -192,7 +192,7 @@ struct FileMenu
 
 	static void openScaleFile(GtkWidget *widget, Synthesizer *synthesizer)
 	{
-		std::string filename = file_dialog(NULL, _("Open Scala(.scl) alternate tuning file"), false, _("Scala scale files"), "*.[Ss][Cc][Ll]", NULL);
+		std::string filename = file_dialog(NULL, _("Open Scala (.scl) alternate tuning file"), false, _("Scala scale files"), "*.[Ss][Cc][Ll]", NULL);
 		if (!filename.empty()) {
 			int error = synthesizer->loadTuningScale(filename.c_str());
 			if (error) {
@@ -205,7 +205,7 @@ Make sure your file has the correct format and try again."));
 
 	static void openKeyboardMap(GtkWidget *widget, Synthesizer *synthesizer)
 	{
-		std::string filename = file_dialog(NULL, _("Open alternate keyboard map(Scala .kbm format)"), false, _("Scala keyboard map files"), "*.[Kk][Bb][Mm]", NULL);
+		std::string filename = file_dialog(NULL, _("Open alternate keyboard map (Scala .kbm format)"), false, _("Scala keyboard map files"), "*.[Kk][Bb][Mm]", NULL);
 		if (!filename.empty()) {
 			int error = synthesizer->loadTuningKeymap(filename.c_str());
 			if (error) {

--- a/src/GUI/editor_menus.cpp
+++ b/src/GUI/editor_menus.cpp
@@ -215,7 +215,7 @@ static void tuning_menu_open_scl(GtkWidget *widget, Synthesizer *synth)
         if (synth->loadTuningScale(filename) != 0) {
             show_error_dialog(parent,
                     _("Failed to load new tuning."),
-                    _("Reading the tuning file failed for some reason. \n"
+                    _("Reading the tuning file failed for some reason.\n"
                       "Make sure your file has the correct format and try again."));
         }
         g_free(filename);
@@ -236,7 +236,7 @@ static void tuning_menu_open_kbm(GtkWidget *widget, Synthesizer *synth)
         if (synth->loadTuningKeymap(filename) != 0) {
             show_error_dialog(parent,
                     _("Failed to load new keyboard map."),
-                    _("Reading the keyboard map file failed for some reason. \n"
+                    _("Reading the keyboard map file failed for some reason.\n"
                       "Make sure your file has the correct format and try again."));
         }
         g_free(filename);


### PR DESCRIPTION
@nixxcode: There are two different versions of the tuning scale/keymap error messages which are also modified in the first commit - with line breaks in `src/GUI/editor_menus.cpp`, without line breaks in `src/GUI/MainMenu.cpp`. Is this on purpose or can these strings be unified?