### PR TITLE
Fix installing of appdata

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -296,7 +296,7 @@ appdata_in_files = data/amsynth.appdata.xml.in
 appdata_in_files += data/dssi-amsynth-plugin.metainfo.xml.in
 appdata_in_files += data/lv2-amsynth-plugin.metainfo.xml.in
 appdata_in_files += data/vst-amsynth-plugin.metainfo.xml.in
-appdata_DATA = $(appdata_in_files:.appdata.xml.in=.appdata.xml)
+appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 @INTLTOOL_XML_RULE@
 
 EXTRA_DIST += $(appdata_in_files)


### PR DESCRIPTION
Without this there are several *.metainfo.xml.in files.

Stolen from fedora [1]

[1] https://src.fedoraproject.org/rpms/amsynth/blob/master/f/amsynth.fixMetainfo.patch

Signed-off-by: Andreas Müller <schnitzeltony@googlemail.com>