### PR TITLE
Support for the Non Session Manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.0)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 #set(CMAKE_VERBOSE_MAKEFILE true)
 
 find_package(PkgConfig REQUIRED)
@@ -116,6 +116,12 @@ add_library(amsynth_core STATIC
         src/UpdateListener.h
         src/VoiceAllocationUnit.cc
         src/VoiceAllocationUnit.h
+        src/DebugMessage.C
+        src/DebugMessage.h
+        src/NsmClient.C
+        src/NsmClient.h
+        src/NsmHandler.C
+        src/NsmHandler.h
         )
 
 #
@@ -178,6 +184,8 @@ target_link_libraries(amsynth
         ${GTK_LIBRARIES}
         ${LASH_LIBRARIES}
         ${SNDFILE_LIBRARIES}
+        ${LIBLO_LIBRARIES}
+        oscpack
         )
 
 #
@@ -186,7 +194,7 @@ target_link_libraries(amsynth
 
 add_library(amsynth_dssi MODULE src/amsynth_dssi.cpp src/amsynth_dssi.h)
 set_target_properties(amsynth_dssi PROPERTIES PREFIX "")
-target_link_libraries(amsynth_dssi amsynth_core)
+target_link_libraries(amsynth_dssi amsynth_core oscpack)
 
 add_executable(amsynth_dssi_gtk
         src/amsynth_dssi_gtk.cpp
@@ -209,6 +217,7 @@ target_link_libraries(amsynth_dssi_gtk
         amsynth_core
         ${GTK_LIBRARIES}
         ${LIBLO_LIBRARIES}
+        oscpack
         )
 
 #
@@ -217,7 +226,7 @@ target_link_libraries(amsynth_dssi_gtk
 
 add_library(amsynth_lv2 MODULE src/amsynth_lv2.cpp)
 set_target_properties(amsynth_lv2 PROPERTIES PREFIX "")
-target_link_libraries(amsynth_lv2 amsynth_core)
+target_link_libraries(amsynth_lv2 amsynth_core oscpack)
 
 
 add_library(amsynth_lv2_gtk MODULE
@@ -237,7 +246,7 @@ add_library(amsynth_lv2_gtk MODULE
         src/amsynth_lv2_ui_gtk.cpp
         )
 set_target_properties(amsynth_lv2_gtk PROPERTIES PREFIX "")
-target_link_libraries(amsynth_lv2_gtk amsynth_core ${GTK_LIBRARIES})
+target_link_libraries(amsynth_lv2_gtk amsynth_core ${GTK_LIBRARIES} oscpack)
 
 add_dependencies(amsynth_lv2 amsynth_lv2_gtk)
 
@@ -259,8 +268,8 @@ add_library(amsynth_vst MODULE
         )
 target_compile_options(amsynth_vst PUBLIC -DWITH_GUI)
 set_target_properties(amsynth_vst PROPERTIES PREFIX "")
-target_link_libraries(amsynth_vst amsynth_core ${GTK_LIBRARIES})
+target_link_libraries(amsynth_vst amsynth_core ${GTK_LIBRARIES} oscpack)
 
 
 add_executable(amsynth_tests src/tests.cpp)
-target_link_libraries(amsynth_tests amsynth_core)
+target_link_libraries(amsynth_tests amsynth_core oscpack)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,7 +194,7 @@ target_link_libraries(amsynth
 
 add_library(amsynth_dssi MODULE src/amsynth_dssi.cpp src/amsynth_dssi.h)
 set_target_properties(amsynth_dssi PROPERTIES PREFIX "")
-target_link_libraries(amsynth_dssi amsynth_core oscpack)
+target_link_libraries(amsynth_dssi amsynth_core ${LIBLO_LIBRARIES} oscpack)
 
 add_executable(amsynth_dssi_gtk
         src/amsynth_dssi_gtk.cpp
@@ -226,7 +226,7 @@ target_link_libraries(amsynth_dssi_gtk
 
 add_library(amsynth_lv2 MODULE src/amsynth_lv2.cpp)
 set_target_properties(amsynth_lv2 PROPERTIES PREFIX "")
-target_link_libraries(amsynth_lv2 amsynth_core oscpack)
+target_link_libraries(amsynth_lv2 amsynth_core ${LIBLO_LIBRARIES} oscpack)
 
 
 add_library(amsynth_lv2_gtk MODULE
@@ -246,7 +246,7 @@ add_library(amsynth_lv2_gtk MODULE
         src/amsynth_lv2_ui_gtk.cpp
         )
 set_target_properties(amsynth_lv2_gtk PROPERTIES PREFIX "")
-target_link_libraries(amsynth_lv2_gtk amsynth_core ${GTK_LIBRARIES} oscpack)
+target_link_libraries(amsynth_lv2_gtk amsynth_core ${GTK_LIBRARIES} ${LIBLO_LIBRARIES} oscpack)
 
 add_dependencies(amsynth_lv2 amsynth_lv2_gtk)
 
@@ -268,8 +268,8 @@ add_library(amsynth_vst MODULE
         )
 target_compile_options(amsynth_vst PUBLIC -DWITH_GUI)
 set_target_properties(amsynth_vst PROPERTIES PREFIX "")
-target_link_libraries(amsynth_vst amsynth_core ${GTK_LIBRARIES} oscpack)
+target_link_libraries(amsynth_vst amsynth_core ${GTK_LIBRARIES} ${LIBLO_LIBRARIES} oscpack)
 
 
 add_executable(amsynth_tests src/tests.cpp)
-target_link_libraries(amsynth_tests amsynth_core oscpack)
+target_link_libraries(amsynth_tests amsynth_core ${LIBLO_LIBRARIES} oscpack)

--- a/include/sigs/sigs.h
+++ b/include/sigs/sigs.h
@@ -1,0 +1,347 @@
+/***************************************************************************************************
+sigs
+
+Simple thread-safe signal/slot C++14 library.
+
+The MIT License (MIT)
+
+Copyright (c) 2015 Morten Kristensen, msk AT nullpointer DOT dk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge, publish, distribute,
+sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES
+OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+***************************************************************************************************/
+
+#ifndef SIGS_SIGNAL_SLOT_H
+#define SIGS_SIGNAL_SLOT_H
+
+#include <cstddef>
+#include <functional>
+#include <initializer_list>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <type_traits>
+#include <utility>
+#include <vector>
+
+// The following is used for making variadic type lists for binding member functions and their
+// parameters.
+namespace sigs {
+
+template <std::size_t... Ns>
+class Seq {
+};
+
+template <std::size_t N, std::size_t... Ns>
+class MakeSeq : public MakeSeq<N - 1, N - 1, Ns...> {
+};
+
+template <std::size_t... Ns>
+class MakeSeq<0, Ns...> : public Seq<Ns...> {
+};
+
+template <std::size_t>
+class Placeholder {
+};
+
+} // namespace sigs
+
+// std::bind uses std::is_placeholder to detect placeholders for unbounded arguments, so it must be
+// overridden to accept the custom sigs::Placeholder type.
+namespace std {
+
+template <size_t N>
+class is_placeholder<sigs::Placeholder<N>> : public integral_constant<std::size_t, N + 1> {
+};
+
+} // namespace std
+
+namespace sigs {
+
+/// When a member function has muliple overloads and you need to use just one of them.
+/** Example:
+    signal.connect(&instance, sigs::Use<int, float>::overloadOf(&ThClass::func));
+    */
+template <typename... Args>
+struct Use {
+  template <typename Cls, typename Ret>
+  static auto overloadOf(Ret (Cls::*MembFunc)(Args...))
+  {
+    return MembFunc;
+  }
+};
+
+class ConnectionBase {
+  template <typename>
+  friend class Signal;
+
+public:
+  void disconnect()
+  {
+    if (deleter) deleter();
+  }
+
+private:
+  std::function<void()> deleter;
+};
+
+using Connection = std::shared_ptr<ConnectionBase>;
+
+namespace {
+
+/// VoidableFunction is used internally to generate a function type depending on whether the return
+/// type of the signal is non-void.
+template <typename T>
+class VoidableFunction {
+public:
+  using func = std::function<void(T)>;
+};
+
+/// Specialization for void return types.
+template <>
+class VoidableFunction<void> {
+public:
+  using func = std::function<void()>;
+};
+
+} // namespace
+
+template <typename>
+class Signal;
+
+template <typename Ret, typename... Args>
+class Signal<Ret(Args...)> {
+  using Slot = std::function<Ret(Args...)>;
+
+  class Entry {
+  public:
+    Entry(const Slot &slot, Connection conn) : slot_(slot), conn_(conn), signal_(nullptr)
+    {
+    }
+
+    Entry(Slot &&slot, Connection conn) : slot_(std::move(slot)), conn_(conn), signal_(nullptr)
+    {
+    }
+
+    Entry(Signal *signal, Connection conn) : conn_(conn), signal_(signal)
+    {
+    }
+
+    const Slot &slot() const
+    {
+      return slot_;
+    }
+
+    Signal *signal() const
+    {
+      return signal_;
+    }
+
+    Connection conn() const
+    {
+      return conn_;
+    }
+
+  private:
+    Slot slot_;
+    Connection conn_;
+    Signal *signal_;
+  };
+
+  using Cont = std::vector<Entry>;
+  using Lock = std::lock_guard<std::mutex>;
+
+public:
+  using ReturnType = Ret;
+  using SlotType = Slot;
+
+  Signal()
+  {
+  }
+
+  virtual ~Signal()
+  {
+    Lock lock(entriesMutex);
+    for (auto &entry : entries) {
+      auto conn = entry.conn();
+      if (conn) {
+        conn->deleter = nullptr;
+      }
+    }
+  }
+
+  Signal(const Signal &rhs)
+  {
+    Lock lock1(entriesMutex);
+    Lock lock2(const_cast<Signal &>(rhs).entriesMutex);
+    entries = rhs.entries;
+  }
+
+  Signal &operator=(const Signal &rhs)
+  {
+    Lock lock1(entriesMutex);
+    Lock lock2(const_cast<Signal &>(rhs).entriesMutex);
+    entries = rhs.entries;
+    return *this;
+  }
+
+  Signal(Signal &&rhs) = default;
+  Signal &operator=(Signal &&rhs) = default;
+
+  Connection connect(const Slot &slot)
+  {
+    Lock lock(entriesMutex);
+    auto conn = makeConnection();
+    entries.emplace_back(Entry(slot, conn));
+    return conn;
+  }
+
+  Connection connect(Slot &&slot)
+  {
+    Lock lock(entriesMutex);
+    auto conn = makeConnection();
+    entries.emplace_back(Entry(std::move(slot), conn));
+    return conn;
+  }
+
+  template <typename Instance, typename MembFunc>
+  Connection connect(Instance *instance, MembFunc Instance::*mf)
+  {
+    Lock lock(entriesMutex);
+    auto slot = bindMf(instance, mf);
+    auto conn = makeConnection();
+    entries.emplace_back(Entry(slot, conn));
+    return conn;
+  }
+
+  /// Connecting a signal will trigger all of its slots when this signal is triggered.
+  Connection connect(Signal &signal)
+  {
+    Lock lock(entriesMutex);
+    auto conn = makeConnection();
+    entries.emplace_back(Entry(&signal, conn));
+    return conn;
+  }
+
+  void clear()
+  {
+    Lock lock(entriesMutex);
+    auto end = entries.end();
+    for (auto it = entries.begin(); it != end; it++) {
+      eraseEntry(it);
+    }
+  }
+
+  void disconnect(Connection conn = nullptr)
+  {
+    if (!conn) {
+      clear();
+      return;
+    }
+
+    Lock lock(entriesMutex);
+
+    auto end = entries.end();
+    for (auto it = entries.begin(); it != end; it++) {
+      if (it->conn() == conn) {
+        eraseEntry(it);
+      }
+    }
+  }
+
+  void disconnect(Signal &signal)
+  {
+    Lock lock(entriesMutex);
+    auto end = entries.end();
+    for (auto it = entries.begin(); it != end; it++) {
+      if (it->signal() == &signal) {
+        eraseEntry(it);
+      }
+    }
+  }
+
+  void operator()(Args &&... args)
+  {
+    Lock lock(entriesMutex);
+    for (auto &entry : entries) {
+      auto *sig = entry.signal();
+      if (sig) {
+        (*sig)(std::forward<Args>(args)...);
+      }
+      else {
+        entry.slot()(std::forward<Args>(args)...);
+      }
+    }
+  }
+
+  template <typename RetFunc = typename VoidableFunction<ReturnType>::func>
+  void operator()(const RetFunc &retFunc, Args &&... args)
+  {
+    static_assert(!isVoidReturn(), "Must have non-void return type!");
+
+    Lock lock(entriesMutex);
+    for (auto &entry : entries) {
+      auto *sig = entry.signal();
+      if (sig) {
+        (*sig)(retFunc, std::forward<Args>(args)...);
+      }
+      else {
+        retFunc(entry.slot()(std::forward<Args>(args)...));
+      }
+    }
+  }
+
+private:
+  Connection makeConnection()
+  {
+    auto conn = std::make_shared<ConnectionBase>();
+    conn->deleter = [this, conn] { this->disconnect(conn); };
+    return conn;
+  }
+
+  /// Expects entries container to be locked beforehand.
+  void eraseEntry(typename Cont::iterator it)
+  {
+    auto conn = it->conn();
+    if (conn) {
+      conn->deleter = nullptr;
+    }
+    entries.erase(it);
+  }
+
+  template <typename Instance, typename MembFunc, std::size_t... Ns>
+  Slot bindMf(Instance *instance, MembFunc Instance::*mf, Seq<Ns...>)
+  {
+    return std::bind(mf, instance, Placeholder<Ns>()...);
+  }
+
+  template <typename Instance, typename MembFunc>
+  Slot bindMf(Instance *instance, MembFunc Instance::*mf)
+  {
+    return bindMf(instance, mf, MakeSeq<sizeof...(Args)>());
+  }
+
+  static constexpr bool isVoidReturn()
+  {
+    return std::is_void<ReturnType>::value;
+  }
+
+  Cont entries;
+  std::mutex entriesMutex;
+};
+
+} // namespace sigs
+
+#endif // SIGS_SIGNAL_SLOT_H

--- a/src/DebugMessage.C
+++ b/src/DebugMessage.C
@@ -1,0 +1,114 @@
+#include <iostream>
+#include <sstream>
+#include <oscpack/osc/OscOutboundPacketStream.h>
+#include <oscpack/ip/UdpSocket.h>
+
+#include "DebugMessage.h"
+
+#define ADDRESS "127.0.0.1"
+#define PORT 7001
+
+#define OUTPUT_BUFFER_SIZE 1024
+
+using namespace std ;
+
+DebugMessage::DebugMessage (void) {
+}
+
+void DebugMessage::SendMessage (string message) {
+  list<string>::iterator a ;
+  string::iterator t ;
+  stringstream Stream  ;
+
+  AddressPattern = "/Message" ;
+  TypeTag = "s" ;
+  Arguments.clear () ;
+  Arguments.push_back (message) ;
+
+  //cout << "Sending Osc Debug Message" << endl ;
+
+  UdpTransmitSocket transmitSocket( IpEndpointName( ADDRESS, PORT ) );
+  char buffer[OUTPUT_BUFFER_SIZE];
+
+  osc::OutboundPacketStream p( buffer, OUTPUT_BUFFER_SIZE );
+
+  p << osc::BeginBundleImmediate << osc::BeginMessage( AddressPattern.c_str() ) ;
+
+  for (a=Arguments.begin(), t=TypeTag.begin(); a!=Arguments.end()&&t!=TypeTag.end();) {
+    string Arg ;
+
+    switch ((*t)) {
+      case ',':
+      case 'N':
+      case 'I': {
+        t++ ;
+        break ;
+      }
+      case 'T': {
+        cout << "True arg: " << endl ;
+        p << true ;
+        t++ ;
+        break ;
+      }
+      case 'F': {
+        cout << "False arg: " << endl ;
+        p << false ;
+        t++ ;
+        break ;
+      }
+      case 'i': {
+        int i ;
+        Arg = *a ;
+
+        Stream.clear() ;
+        Stream.str("") ;
+        Stream << Arg ;
+        Stream >> i ;
+        p << i ;
+        t++ ;
+        a++ ;
+        break ;
+      }
+      case 'f': {
+        Arg = *a ;
+
+        float f ;
+        Stream.clear() ;
+        Stream.str("") ;
+        Stream << Arg ;
+        Stream >> f ;
+        p << f ;
+        t++ ;
+        a++ ;
+        break ;
+      }
+      case 'd': {
+        Arg = *a ;
+
+        double d ;
+        Stream.clear() ;
+        Stream.str("") ;
+        Stream << Arg ;
+        Stream >> d ;
+        p << d ;
+        t++ ;
+        a++ ;
+        break ;
+      }
+      case 's': {
+        string s = (*a) ;
+        p << s.c_str() ;
+        t++ ;
+        a++ ;
+        break ;
+      }
+      default: {
+        t++ ;
+      }
+    }
+  }
+
+  p << osc::EndMessage << osc::EndBundle ;
+
+  transmitSocket.Send( p.Data(), p.Size() );
+}

--- a/src/DebugMessage.h
+++ b/src/DebugMessage.h
@@ -1,0 +1,17 @@
+#ifndef __DebugMessage__
+#define __DebugMessage__
+
+#include <list>
+#include <string>
+
+
+class DebugMessage {
+public:
+  DebugMessage (void) ;
+  void SendMessage (std::string message) ;
+  std::string AddressPattern ;
+  std::string TypeTag ;
+  std::list<std::string> Arguments ;
+} ;
+
+#endif // __DebugMessage__

--- a/src/NsmClient.C
+++ b/src/NsmClient.C
@@ -1,0 +1,143 @@
+#include <non/nsm.h>                                          
+#include "NsmClient.h"                                          
+#include "main.h"
+#include "DebugMessage.h"
+
+using namespace std ;
+
+
+NsmClient *NSMClient ;
+
+DebugMessage NsmClient::debugMessage ;
+
+
+void NsmClient::Debug (string message) {
+  //DebugString (message) ;
+  debugMessage.SendMessage (message) ;
+}
+
+
+
+
+int NsmClient::openCallback (const char *path, const char *displayName, const char *clientId, char **outMsg, void *userData) {
+  (void)outMsg ;
+
+  NsmClient *nsmClient = (NsmClient*)userData ;
+  nsmClient->Debug ("NsmClient: openCallback()\n") ;
+  return nsmClient->open (path, displayName, clientId) ;                                  
+}                                                         
+                                                          
+int NsmClient::saveCallback (char **outMsg, void *userData) {
+  (void)outMsg ;
+
+  NsmClient *nsmClient = (NsmClient*)userData ;
+  nsmClient->Debug ("NsmClient: saveCallback()\n") ;
+  return nsmClient->save () ;                                      
+}                                                         
+                                                          
+
+void NsmClient::activeCallback (int isActive, void *userData) {
+  NsmClient *nsmClient = (NsmClient*)userData ;
+  nsmClient->Debug ("NsmClient: activeCallback()\n") ;
+
+  if (isActive == 1) {
+    nsmClient->Debug ("Nsm is active\n") ;
+    nsmClient->active (true) ;
+  }
+  else {
+    nsmClient->Debug ("Nsm is NOT active\n") ;
+    nsmClient->active (false) ;
+  }
+}                                                         
+
+void NsmClient::setOpenResult (int result) {
+  openResult = result ;
+}
+
+void NsmClient::setSaveResult (int result) {
+  saveResult = result ;
+}
+
+void NsmClient::setActiveResult (int result) {
+  activeResult = result ;
+}
+                                                          
+
+NsmClient::NsmClient (std::string programName) : nsm(0) {
+  NSMClient = this ;
+  this->programName = programName ;
+
+  openResult = -1 ;
+  saveResult = -1 ;
+  activeResult = -1 ;
+}
+
+void NsmClient::Init (void) {
+  Debug ("NsmClient: Constructor()\n") ;
+
+  const char *nsm_url = getenv("NSM_URL") ;
+
+  if (nsm_url) {
+    Debug ("nsm_url: ") ;
+    Debug (string(nsm_url)) ;
+    Debug ("\n") ;
+
+    nsm = nsm_new ();
+
+    nsm_set_open_callback (nsm, openCallback, this);
+    nsm_set_save_callback (nsm, saveCallback, this);
+    nsm_set_active_callback (nsm, activeCallback, this);
+
+    if (nsm_init_thread (nsm, nsm_url) == 0) {
+      nsm_send_announce( nsm, "AmSynth", "", programName.c_str() );
+      nsm_thread_start (nsm) ;
+    }
+    else {
+      nsm_free( nsm );
+      nsm = 0;
+    }
+
+    Debug ("NsmClient: Registered Callbacks\n") ;
+  }
+}
+
+
+
+NsmClient::~NsmClient (void) {
+  Debug ("NsmClient: Destructor()\n") ;
+  if (nsm != 0) {
+    nsm_thread_stop (nsm) ;
+    nsm_free( nsm );
+  }
+}
+
+int NsmClient::open (const char* name, const char* displayName, const char* clientId) {
+  Debug ("NsmClient: open()\n") ;
+  Open (string(name), string(displayName), string(clientId)) ;
+
+  Debug ("Open Result: ") ;
+  Debug (to_string (openResult)) ;
+  Debug ("\n") ;
+
+  return openResult ;
+}
+
+int NsmClient::save (void) {
+  Debug ("NsmClient: save()\n") ;
+  Save () ;
+
+  Debug ("Save Result: ") ;
+  Debug (to_string (saveResult)) ;
+  Debug ("\n") ;
+
+  return saveResult ;
+}
+
+void NsmClient::active (bool isActive) {
+  Debug ("NsmClient: active()\n") ;
+  Active (isActive) ;
+
+  Debug ("Active Result: ") ;
+  Debug (to_string (activeResult)) ;
+  Debug ("\n") ;
+}

--- a/src/NsmClient.h
+++ b/src/NsmClient.h
@@ -1,0 +1,50 @@
+#ifndef __NsmClient__
+#define __NsmClient__
+
+#include <string>
+#include <mutex>
+#include <condition_variable>
+#include <sigs/sigs.h>
+#include "DebugMessage.h"
+
+typedef void * nsm_client_t ;
+
+class NsmClient {
+
+public:
+  static int openCallback (const char* name, const char* displayName, const char* clientId, char** outMsg, void* userData) ;
+  static int saveCallback (char** outMsg, void* userData) ;
+  static void activeCallback (int isActive, void* userData) ;
+  static DebugMessage debugMessage ;
+
+  NsmClient (std::string programName) ;
+  ~NsmClient (void) ;
+  int open (const char* name, const char* displayName, const char* clientId) ;
+  int save (void) ;
+  void active (bool isActive) ;
+  void Init (void) ;
+  void Debug (std::string message) ;
+  void setOpenResult (int result) ;
+  void setSaveResult (int result) ;
+  void setActiveResult (int result) ;
+
+  std::condition_variable_any openFinished ;
+  std::condition_variable_any saveFinished ;
+  std::condition_variable_any activeFinished ;
+
+//signals:
+  sigs::Signal<void(std::string, std::string, const std::string&)> Open ;
+  sigs::Signal<void(void)> Save ;
+  sigs::Signal <void(bool&)> Active ;
+  sigs::Signal<void(const std::string&)> DebugString ;
+
+private:
+  std::string programName ;
+  int openResult ;
+  int saveResult ;
+  int activeResult ;
+  nsm_client_t *nsm ;
+} ;
+
+
+#endif //__NsmClient__

--- a/src/NsmHandler.C
+++ b/src/NsmHandler.C
@@ -1,0 +1,132 @@
+#include <sys/wait.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <iostream>
+#include <sstream>
+#include <csignal>
+#include <non/nsm.h>
+#include "NsmHandler.h"
+#include "main.h"
+#include "NsmClient.h"
+#include "DebugMessage.h"
+
+using namespace std ;
+
+
+NsmHandler::NsmHandler( NsmClient *nsmClient) {
+  loadStatus = LoadStatus::Ok ;
+  nsmActive = false ;
+  setNsmClient (nsmClient) ;
+  SetFilePaths ("NotSet") ;
+}
+
+
+NsmHandler::~NsmHandler() {
+}
+
+
+void NsmHandler::SaveAll (void) {
+  if (!(BankPath.empty())) {
+    Debug ("Saving bank ...") ;
+    amsynth_save_bank(BankPath.c_str());
+  }
+
+  if (!(PresetPath.empty())) {
+    if (PresetFile.is_open())
+      PresetFile.close () ;
+	PresetFile.open (PresetPath) ;
+	if (PresetFile.is_open()) {
+      Debug ("Saving preset ...") ;
+      PresetFile << amsynth_get_preset_number() ;
+	  PresetFile.close() ;
+	}
+  }
+}
+
+
+
+void NsmHandler::SetFilePaths (string Path) {
+  if (!(Path.empty()))  {
+    RootPath = BankPath = PresetPath = Path ;
+    BankPath.append ("/bank") ;
+    PresetPath.append ("/preset_number") ;
+  }
+}
+
+
+void NsmHandler::setNsmClient (NsmClient *client) {
+  nsmClient = client ;
+  nsmClient->Open.connect (this, sigs::Use<string,string,string>::overloadOf (&NsmHandler::NsmOpen)) ;
+  nsmClient->Save.connect (this, &NsmHandler::NsmSave) ;
+  nsmClient->Active.connect (this, sigs::Use<bool>::overloadOf (&NsmHandler::NsmActive)) ;
+  nsmClient->DebugString.connect (this, sigs::Use<string>::overloadOf (&NsmHandler::Debug)) ;
+}
+
+
+void NsmHandler::Debug (string message) {
+  nsmClient->Debug (message) ;
+}
+
+
+void NsmHandler::NsmOpen (string Name, string DisplayName, string ClientId) {
+  stringstream Stream ;
+
+  Stream << "NsmHandler::NsmOpen()\n" ;
+  Stream << "Name: " << Name << "\n" ;
+  Stream << "DisplayName: " << DisplayName << "\n" ;
+  Stream << "ClientId: " << ClientId << "\n" ;
+  Debug (Stream.str()) ;
+
+  // Set the paths of the bank and preset files.
+  SetFilePaths (Name) ;
+
+  // Create a unique directory in which to create the bank and preset files
+  // Note mkdir is unix-specific; please add other os versions here for different platforms.
+  mkdir (RootPath.c_str(), S_IRUSR | S_IWUSR | S_IXUSR) ;
+
+  ifstream bankStream (BankPath.c_str()) ;
+
+  if (bankStream.good()) {
+    amsynth_load_bank(BankPath.c_str());
+
+    nsmClient->setOpenResult (ERR_OK) ;
+    loadStatus = LoadStatus::Ok ;
+  }
+  else {
+    nsmClient->setOpenResult (ERR_OK) ;
+    loadStatus = LoadStatus::NoSuchFile ;
+  }
+
+  ifstream presetStream (PresetPath.c_str()) ;
+
+  if (presetStream.good()) {
+    int preset_number ;
+    presetStream >> preset_number ;
+    amsynth_set_preset_number(preset_number);
+
+    nsmClient->setOpenResult (ERR_OK) ;
+    loadStatus = LoadStatus::Ok ;
+  }
+  else {
+    nsmClient->setOpenResult (ERR_OK) ;
+    loadStatus = LoadStatus::NoSuchFile ;
+  }
+}
+
+
+void NsmHandler::NsmSave (void) {
+  Debug ("NsmHandler::NsmSave()\n") ;
+  if (loadStatus != LoadStatus::Error) {
+    SaveAll () ;
+    nsmClient->setSaveResult (ERR_OK) ;
+  }
+  else {
+    nsmClient->setSaveResult (ERR_GENERAL) ;
+  }
+}
+
+void NsmHandler::NsmActive (bool isActive) {
+  nsmActive = isActive ;
+  Debug ("NsmHandler::NsmActive()\n") ;
+  nsmClient->setActiveResult (ERR_OK) ;
+}

--- a/src/NsmHandler.h
+++ b/src/NsmHandler.h
@@ -1,0 +1,44 @@
+#ifndef NsmHandler_H
+#define NsmHandler_H
+
+#include <string>
+#include <fstream>
+
+class NsmClient ;
+
+class NsmHandler {
+public:
+
+  NsmHandler( NsmClient *nsmClient) ;
+
+  ~NsmHandler( ) ;
+
+
+private:
+
+  void SaveAll (void) ;
+  void SetFilePaths (std::string Path);
+
+  void setNsmClient (NsmClient *client) ;
+  void NsmOpen (std::string Name, std::string DisplayName, std::string ClientId) ;
+  void NsmSave (void) ;
+  void NsmActive (bool isActive) ;
+  void Debug (std::string message) ;
+
+
+  enum class LoadStatus {Ok, NoSuchFile, Error} ;
+  LoadStatus loadStatus ;
+
+  NsmClient *nsmClient ;
+
+  std::string RootPath ;
+  std::ofstream RootFile ;
+  std::string BankPath ;
+  std::ofstream BankFile ;
+  std::string PresetPath ;
+  std::ofstream PresetFile ;
+
+  bool nsmActive ; /**< Set true if running in a Non session */
+};
+
+#endif //NsmHandler_H

--- a/src/Preset.cc
+++ b/src/Preset.cc
@@ -312,7 +312,7 @@ int parameter_get_display (int parameter_index, float parameter_value, char *buf
 const char **parameter_get_value_strings (int parameter_index)
 {
     static std::vector<std::vector<const char *> > parameterStrings(kAmsynthParameterCount);
-    if (parameter_index < 0 || parameter_index >= parameterStrings.size())
+    if (parameter_index < 0 || parameter_index >= (int)parameterStrings.size())
         return NULL;
 
     std::vector<const char *> & strings = parameterStrings[parameter_index];
@@ -394,13 +394,13 @@ static std::vector<bool> s_ignoreParameter(kAmsynthParameterCount);
 
 bool Preset::shouldIgnoreParameter(int parameter)
 {
-	assert(parameter >= 0 && parameter < s_ignoreParameter.size());
+	assert(parameter >= 0 && parameter < (int)s_ignoreParameter.size());
 	return s_ignoreParameter[parameter];
 }
 
 void Preset::setShouldIgnoreParameter(int parameter, bool ignore)
 {
-	assert(parameter >= 0 && parameter < s_ignoreParameter.size());
+	assert(parameter >= 0 && parameter < (int)s_ignoreParameter.size());
 	s_ignoreParameter[parameter] = ignore;
 }
 

--- a/src/main.cc
+++ b/src/main.cc
@@ -20,6 +20,8 @@
  */
 
 #include "main.h"
+#include "NsmClient.h"
+#include "NsmHandler.h"
 
 #if HAVE_CONFIG_H
 #include "config.h"
@@ -62,6 +64,7 @@
 
 #include "gettext.h"
 #define _(string) gettext (string)
+
 
 using namespace std;
 
@@ -278,6 +281,7 @@ int main( int argc, char *argv[] )
 {
 	srand((unsigned) time(NULL));
 
+
 #ifdef ENABLE_REALTIME
 	sched_realtime();
 
@@ -418,9 +422,13 @@ int main( int argc, char *argv[] )
 
 	s_synthesizer = new Synthesizer();
 	s_synthesizer->setSampleRate(config.sample_rate);
-	
+
 	amsynth_load_bank(config.current_bank_file.c_str());
 	amsynth_set_preset_number(initial_preset_no);
+
+    NsmClient NSMC (argv[0]) ;
+    NsmHandler nsmHandler (&NSMC) ;
+    NSMC.Init () ;
 
 	if (config.current_tuning_file != "default")
 		amsynth_load_tuning_file(config.current_tuning_file.c_str());

--- a/src/main.h
+++ b/src/main.h
@@ -26,6 +26,7 @@
 
 #ifdef __cplusplus
 #include <vector>
+
 extern "C" {
 #endif
 
@@ -47,6 +48,7 @@ extern void amsynth_audio_callback(
         std::vector<amsynth_midi_cc_t> &midi_out);
 
 }
+
 #endif
 
 #endif


### PR DESCRIPTION
These changes add two new classes which handle the protocol specified by the Non Session Manager, allowing AmSynth to save and restore its state (bank and preset) on a per-session basis when invoked via NSM.