### PR TITLE
Fix a format overflow compiler warning

### DIFF
--- a/src/GUI/PresetControllerView.cpp
+++ b/src/GUI/PresetControllerView.cpp
@@ -90,7 +90,7 @@ static GtkWidget * button_with_image(const gchar *stock_id, const gchar *label)
 static gboolean on_output(GtkSpinButton *spin, gpointer user_data)
 {
 	static const char *names[12] = {"C", "C#", "D", "D#", "E", "F", "F#", "G", "G#", "A", "A#", "B"};
-	gchar text[8];
+	gchar text[12];
 	gint value = gtk_spin_button_get_value_as_int (spin);
 	sprintf (text, "%s%d", names[value % 12], value / 12 - 1);
 	gtk_entry_set_text (GTK_ENTRY (spin), text);


### PR DESCRIPTION
Compiling with -Wformat-overflow, GCC report this warning