### PR TITLE
Do not return -1 in as bool

### DIFF
--- a/src/AudioOutput.h
+++ b/src/AudioOutput.h
@@ -88,7 +88,7 @@ private:
 
 class NullAudioOutput : public GenericOutput { public:
 	virtual	int  init  () { return -1; }
-	virtual	bool Start () { return -1; }
+	virtual	bool Start () { return false; }
 	virtual	void Stop  () {}
 };
 


### PR DESCRIPTION
Returning anything but 0 (or false) is the same as returning true in a 
function with bool as return value type. Return false instead.