### PR TITLE
Improve preset listing performance

### DIFF
--- a/src/GUI/PresetControllerView.cpp
+++ b/src/GUI/PresetControllerView.cpp
@@ -160,7 +160,7 @@ void PresetControllerViewImpl::on_combo_changed (GtkWidget *widget, PresetContro
 
 	if (widget == that->bank_combo) {
 		gint bank = gtk_combo_box_get_active (GTK_COMBO_BOX (that->bank_combo));
-		const std::vector<BankInfo> banks = PresetController::getPresetBanks();
+		const std::vector<BankInfo> &banks = PresetController::getPresetBanks();
 		that->presetController->loadPresets(banks[bank].file_path.c_str());
 	}
 
@@ -227,7 +227,7 @@ void PresetControllerViewImpl::update()
 {
 	inhibit_combo_callback = true;
 
-	const std::vector<BankInfo> banks = PresetController::getPresetBanks();
+	const std::vector<BankInfo> &banks = PresetController::getPresetBanks();
 
 	char text [48] = "";
 

--- a/src/GUI/editor_menus.cpp
+++ b/src/GUI/editor_menus.cpp
@@ -109,7 +109,7 @@ presets_menu_new(GtkAdjustment **adjustments)
 
     GtkWidget *presets_menu = gtk_menu_new ();
 
-    const std::vector<BankInfo> banks = PresetController::getPresetBanks();
+    const std::vector<BankInfo> &banks = PresetController::getPresetBanks();
 
     for (size_t b=0; b<banks.size(); b++) {
         snprintf(text, sizeof(text), "[%s] %s", banks[b].read_only ? _("F") : _("U"), banks[b].name.c_str());

--- a/src/amsynth_dssi.cpp
+++ b/src/amsynth_dssi.cpp
@@ -136,7 +136,7 @@ static const DSSI_Program_Descriptor *get_program(LADSPA_Handle Instance, unsign
 	descriptor.Program = Index % PresetController::kNumPresets;
 	descriptor.Bank = Index / PresetController::kNumPresets;
 
-	const std::vector<BankInfo> banks = PresetController::getPresetBanks();
+	const std::vector<BankInfo> &banks = PresetController::getPresetBanks();
 	if (descriptor.Bank < banks.size())
 	{
 		if (descriptor.Bank != s_lastBankGet) {
@@ -157,7 +157,7 @@ static void select_program(LADSPA_Handle Instance, unsigned long Bank, unsigned 
 
 	TRACE_ARGS("Bank = %d Index = %d", Bank, Index);
 
-	const std::vector<BankInfo> banks = PresetController::getPresetBanks();
+	const std::vector<BankInfo> &banks = PresetController::getPresetBanks();
 
 	if (Bank < banks.size() && Index < PresetController::kNumPresets) {
 		s_presetController->loadPresets(banks[Bank].file_path.c_str());


### PR DESCRIPTION
Eliminating the copy accelerates the program listing by a vast amount.

In DSSI, performance is a problem with naspro-bridges installed, because when it lists program in a loop as the host loads LV2, the host will hang for a whole minute while it processes.

Before: `./load-amsynth .libs/amsynth_dssi.so  58,52s user 0,19s system 98% cpu 59,699 total`
After: `./load-amsynth .libs/amsynth_dssi.so  0,37s user 0,05s system 98% cpu 0,421 total`

I've applied some identical changes throughout the program.

[load-amsynth.cc.gz](https://github.com/amsynth/amsynth/files/3236815/load-amsynth.cc.gz)
