### PR TITLE
HiDPI scaling

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,6 @@
 amsynth 1.11.0 -- UNRELEASED
 
-  - Implemented rudimentary UI scaling for HiDPI displays
+  - Implemented UI upscaling for background and controls on HiDPI displays
 
 
 amsynth 1.10.0 -- 2020-05-07

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+amsynth 1.11.0 -- UNRELEASED
+
+  - Implemented rudimentary UI scaling for HiDPI displays
+
+
 amsynth 1.10.0 -- 2020-05-07
 
   - Implemented smoothing / de-zippering to improve sound quality while adjusting parameters

--- a/src/GUI/bitmap_button.h
+++ b/src/GUI/bitmap_button.h
@@ -30,7 +30,8 @@ GtkWidget *bitmap_button_new (
 	GdkPixbuf *,
 	gint frame_width,
 	gint frame_height,
-	gint frame_count
+	gint frame_count,
+	gint scaling_factor
 );
 
 void bitmap_button_set_bg (

--- a/src/GUI/bitmap_knob.h
+++ b/src/GUI/bitmap_knob.h
@@ -29,7 +29,8 @@ GtkWidget *bitmap_knob_new( GtkAdjustment *,
 							GdkPixbuf *,
 							gint frame_width,
 							gint frame_height,
-							gint frame_count );
+							gint frame_count,
+							gint scaling_factor);
 
 void bitmap_knob_set_bg (GtkWidget *, GdkPixbuf *);
 

--- a/src/GUI/bitmap_popup.c
+++ b/src/GUI/bitmap_popup.c
@@ -35,6 +35,7 @@ typedef struct {
 	gint frame_width;
 	gint frame_height;
 	gint frame_count;
+	gint scaling_factor;
 	
 	GtkWidget *menu;
 
@@ -59,7 +60,8 @@ bitmap_popup_new( GtkAdjustment *adjustment,
 				 GdkPixbuf *pixbuf,
 				 gint frame_width,
 				 gint frame_height,
-				 gint frame_count )
+				 gint frame_count,
+				 gint scaling_factor)
 {
 	bitmap_popup *self = g_malloc0 (sizeof(bitmap_popup));
 
@@ -68,6 +70,7 @@ bitmap_popup_new( GtkAdjustment *adjustment,
 	self->frame_width	= frame_width;
 	self->frame_height	= frame_height;
 	self->frame_count	= frame_count;
+	self->scaling_factor = scaling_factor;
 
 	g_object_set_data_full (G_OBJECT (self->drawing_area), bitmap_popup_key, self, (GDestroyNotify) g_free);
 	g_assert (g_object_get_data (G_OBJECT (self->drawing_area), bitmap_popup_key));
@@ -76,7 +79,7 @@ bitmap_popup_new( GtkAdjustment *adjustment,
 
 	g_signal_connect (G_OBJECT (self->drawing_area), "button-release-event", G_CALLBACK (bitmap_popup_button_release), NULL);
 
-	gtk_widget_set_size_request (self->drawing_area, frame_width, frame_height);
+	gtk_widget_set_size_request (self->drawing_area, frame_width * scaling_factor, frame_height * scaling_factor);
 	
 	// set up event mask
 	gint event_mask = gtk_widget_get_events (self->drawing_area);
@@ -141,8 +144,13 @@ bitmap_popup_expose( GtkWidget *widget, GdkEventExpose *event )
 
 	cairo_t *cr = gdk_cairo_create (event->window);
 
+	cairo_scale (cr, self->scaling_factor, self->scaling_factor);
+
 	if (self->background) {
 		gdk_cairo_set_source_pixbuf (cr, self->background, 0, 0);
+		// CAIRO_EXTEND_NONE results in a ugly border when upscaling
+		cairo_pattern_t *pattern = cairo_get_source (cr);
+		cairo_pattern_set_extend (pattern, CAIRO_EXTEND_PAD);
 		cairo_paint (cr);
 	}
 

--- a/src/GUI/bitmap_popup.h
+++ b/src/GUI/bitmap_popup.h
@@ -30,7 +30,8 @@ GtkWidget *bitmap_popup_new (
 	GdkPixbuf *,
 	gint frame_width,
 	gint frame_height,
-	gint frame_count
+	gint frame_count,
+	gint scaling_factor
 );
 
 void bitmap_popup_set_bg (

--- a/src/GUI/editor_pane.c
+++ b/src/GUI/editor_pane.c
@@ -228,6 +228,17 @@ button_release_event (GtkWidget *widget, GdkEventButton *event, GtkWidget *prese
 #define KEY_CONTROL_PARAM_NAME	"param_name"
 #define KEY_CONTROL_PARAM_NUM	"param_num"
 
+static int get_scaling_factor ()
+{
+	GSettings *settings = g_settings_new ("org.gnome.desktop.interface");
+	int scaling_factor = g_settings_get_uint (settings, "scaling-factor");
+	g_object_ref_sink (settings);
+	if (scaling_factor > 0) {
+		return scaling_factor;
+	}
+	return 1;
+}
+
 GtkWidget *
 editor_pane_new (void *synthesizer, GtkAdjustment **adjustments, gboolean is_plugin)
 {
@@ -250,12 +261,7 @@ editor_pane_new (void *synthesizer, GtkAdjustment **adjustments, gboolean is_plu
 
 	g_is_plugin = is_plugin;
 
-	GSettings *settings = g_settings_new ("org.gnome.desktop.interface");
-	int gnome_scaling_factor = g_settings_get_uint (settings, "scaling-factor");
-	if (gnome_scaling_factor > 0) {
-		editor_scaling_factor = gnome_scaling_factor;
-	}
-	g_object_ref_sink (settings);
+	editor_scaling_factor = get_scaling_factor ();
 
 	GtkWidget *fixed = gtk_fixed_new ();
 	gtk_widget_set_size_request (fixed, 400, 300);

--- a/src/GUI/editor_pane.c
+++ b/src/GUI/editor_pane.c
@@ -39,6 +39,8 @@
 
 static GdkPixbuf *editor_pane_bg = NULL;
 
+static int editor_scaling_factor = 1;
+
 ////////////////////////////////////////////////////////////////////////////////
 
 typedef struct
@@ -63,7 +65,11 @@ static gboolean
 editor_pane_expose_event_handler (GtkWidget *widget, gpointer data)
 {
 	cairo_t *cr = gdk_cairo_create (gtk_widget_get_window (widget));
+	cairo_scale (cr, editor_scaling_factor, editor_scaling_factor);
 	gdk_cairo_set_source_pixbuf (cr, editor_pane_bg, 0, 0);
+	// CAIRO_EXTEND_NONE results in a ugly border when upscaling
+	cairo_pattern_t *pattern = cairo_get_source (cr);
+	cairo_pattern_set_extend (pattern, CAIRO_EXTEND_PAD);
 	cairo_paint (cr);
 	cairo_destroy (cr);
 	return FALSE;
@@ -244,6 +250,13 @@ editor_pane_new (void *synthesizer, GtkAdjustment **adjustments, gboolean is_plu
 
 	g_is_plugin = is_plugin;
 
+	GSettings *settings = g_settings_new ("org.gnome.desktop.interface");
+	int gnome_scaling_factor = g_settings_get_uint (settings, "scaling-factor");
+	if (gnome_scaling_factor > 0) {
+		editor_scaling_factor = gnome_scaling_factor;
+	}
+	g_object_ref_sink (settings);
+
 	GtkWidget *fixed = gtk_fixed_new ();
 	gtk_widget_set_size_request (fixed, 400, 300);
 	
@@ -309,7 +322,9 @@ editor_pane_new (void *synthesizer, GtkAdjustment **adjustments, gboolean is_plu
 			g_free (bg_name);
 			g_free (path);
 			
-			gtk_widget_set_size_request (fixed, gdk_pixbuf_get_width (editor_pane_bg), gdk_pixbuf_get_height (editor_pane_bg));
+			gint width = gdk_pixbuf_get_width (editor_pane_bg) * editor_scaling_factor;
+			gint height = gdk_pixbuf_get_height (editor_pane_bg) * editor_scaling_factor;
+			gtk_widget_set_size_request (fixed, width, height);
 		}
 		
 		//// Load resources
@@ -378,25 +393,25 @@ editor_pane_new (void *synthesizer, GtkAdjustment **adjustments, gboolean is_plu
 			
 			if (g_strcmp0 (KEY_CONTROL_TYPE_KNOB, type) == 0)
 			{
-				widget = bitmap_knob_new (adj, res->pixbuf, res->fr_width, res->fr_height, res->fr_count);
+				widget = bitmap_knob_new (adj, res->pixbuf, res->fr_width, res->fr_height, res->fr_count, editor_scaling_factor);
 				bitmap_knob_set_bg (widget, subpixpuf);
 				bitmap_knob_set_parameter_index (widget, i);
 			}
 			else if (g_strcmp0 (KEY_CONTROL_TYPE_BUTTON, type) == 0)
 			{
-				widget = bitmap_button_new (adj, res->pixbuf, res->fr_width, res->fr_height, res->fr_count);
+				widget = bitmap_button_new (adj, res->pixbuf, res->fr_width, res->fr_height, res->fr_count, editor_scaling_factor);
 				bitmap_button_set_bg (widget, subpixpuf);
 			}
 			else if (g_strcmp0 (KEY_CONTROL_TYPE_POPUP, type) == 0)
 			{
 				const char **value_strings = parameter_get_value_strings((int) i);
-				widget = bitmap_popup_new (adj, res->pixbuf, res->fr_width, res->fr_height, res->fr_count);
+				widget = bitmap_popup_new (adj, res->pixbuf, res->fr_width, res->fr_height, res->fr_count, editor_scaling_factor);
 				bitmap_popup_set_strings (widget, value_strings);
 				bitmap_popup_set_bg (widget, subpixpuf);
 			}
 			
 			g_signal_connect_after(G_OBJECT(widget), "button-press-event", G_CALLBACK (on_control_press), GINT_TO_POINTER(i));
-			gtk_fixed_put (GTK_FIXED (fixed), widget, pos_x, pos_y);
+			gtk_fixed_put (GTK_FIXED (fixed), widget, pos_x * editor_scaling_factor, pos_y * editor_scaling_factor);
 			
 #if ENABLE_LAYOUT_EDIT
 			gtk_buildable_set_name (GTK_BUILDABLE (widget), control_name);

--- a/src/VoiceBoard/VoiceBoard.cpp
+++ b/src/VoiceBoard/VoiceBoard.cpp
@@ -173,9 +173,10 @@ VoiceBoard::ProcessSamplesMix	(float *buffer, int numSamples, float vol)
 	// Osc Mix
 	//
 	for (int i=0; i<numSamples; i++) {
-		float osc1vol = (1.f - mOscMix.tick()) / 2.f;
-		float osc2vol = (1.f - osc1vol);
 		float ringMod = mRingModAmt.tick();
+		float oscMix = mOscMix.tick();
+		float osc1vol = (1.F - ringMod) * (1.F - oscMix) / 2.F;
+		float osc2vol = (1.F - ringMod) * (1.F + oscMix) / 2.F;
 		osc1buf[i] =
 			osc1vol * osc1buf[i] +
 			osc2vol * osc2buf[i] +


### PR DESCRIPTION
This patch improves the appearance of the graphical "editor" area (knobs and buttons etc.) when using a HiDPI display with a scale factor. The results are quite blurry due to upscaling the low-resolution graphics, but better than having a tiny UI.

It reads the `org.gnome.desktop.interface` `scaling-factor` setting to determine by how much to scale the controls and background.

Note that other icons in the app (in File dialogs, toolbars, checkboxes, About dialog) do not respect the scaling factor, as GTK2 does not natively support this.

Tested and verified on Pop!OS 20.04 LTS using GNOME & X11 windowing system. Not able to try Wayland as my computer has NVIDIA graphics.