### PR TITLE
Ignore app settings in plugins

### DIFF
--- a/src/GUI/MainMenu.cpp
+++ b/src/GUI/MainMenu.cpp
@@ -474,6 +474,8 @@ struct ConfigMenu
 		int newValue = index;
 		int currentValue = synthesizer->getMidiChannel();
 		if (currentValue != newValue) {
+			Configuration::get().midi_channel = newValue;
+			Configuration::get().save();
 			synthesizer->setMidiChannel(newValue);
 		}
 	}

--- a/src/MidiController.cpp
+++ b/src/MidiController.cpp
@@ -21,7 +21,6 @@
 
 #include "MidiController.h"
 
-#include "Configuration.h"
 #include "filesystem.h"
 #include "midi.h"
 #include "VoiceBoard/Synth--.h"
@@ -41,8 +40,6 @@ MidiController::MidiController()
 void
 MidiController::HandleMidiData(const unsigned char* bytes, unsigned numBytes)
 {
-	Configuration & config = Configuration::get();
-
     for (unsigned i=0; i<numBytes; i++)
 	{
 		const unsigned char byte = bytes[i];
@@ -57,7 +54,7 @@ MidiController::HandleMidiData(const unsigned char* bytes, unsigned numBytes)
 		}
 		// now we have at least one data byte
 
-		bool ignore = config.midi_channel && ((int) channel != config.midi_channel - 1);
+		bool ignore = (assignedChannel > 0) && ((int) channel != assignedChannel - 1);
 
 		switch (status & 0xf0)
 		{
@@ -310,7 +307,7 @@ MidiController::setControllerForParameter(Param paramId, int cc)
 void
 MidiController::generateMidiOutput(std::vector<amsynth_midi_cc_t> &output)
 {
-	unsigned char outputChannel = std::max(0, Configuration::get().midi_channel - 1);
+	unsigned char outputChannel = std::max(0, assignedChannel - 1);
 	
 	for (int paramId = 0; paramId < kAmsynthParameterCount; paramId++) {
 		int cc = _param_to_cc_map[paramId];

--- a/src/MidiController.h
+++ b/src/MidiController.h
@@ -66,6 +66,8 @@ public:
 
 	void 	generateMidiOutput	(std::vector<amsynth_midi_cc_t> &);
 
+	unsigned char assignedChannel = 0; // 0 denotes any channel
+
 private:
 	void dispatch_note(unsigned char ch,
 		       unsigned char note, unsigned char vel);

--- a/src/Synthesizer.cpp
+++ b/src/Synthesizer.cpp
@@ -21,7 +21,6 @@
 
 #include "Synthesizer.h"
 
-#include "Configuration.h"
 #include "MidiController.h"
 #include "PresetController.h"
 #include "VoiceAllocationUnit.h"
@@ -39,20 +38,10 @@ Synthesizer::Synthesizer()
 , _presetController(nullptr)
 , _voiceAllocationUnit(nullptr)
 {
-	Configuration &config = Configuration::get();
-
 	_voiceAllocationUnit = new VoiceAllocationUnit;
 	_voiceAllocationUnit->SetSampleRate((int) _sampleRate);
-	_voiceAllocationUnit->SetMaxVoices(config.polyphony);
-	_voiceAllocationUnit->setPitchBendRangeSemitones(config.pitch_bend_range);
-	
-	if (config.current_tuning_file != "default")
-		_voiceAllocationUnit->loadScale(config.current_tuning_file.c_str());
 
-	Preset::setIgnoredParameterNames(config.ignored_parameters);
 	_presetController = new PresetController;
-	_presetController->loadPresets(config.current_bank_file.c_str());
-	_presetController->selectPreset(0);
 	_presetController->getCurrentPreset().AddListenerToAll(_voiceAllocationUnit);
 	
 	_midiController = new MidiController();
@@ -184,12 +173,12 @@ void Synthesizer::setMaxNumVoices(int value)
 
 unsigned char Synthesizer::getMidiChannel()
 {
-	return Configuration::get().midi_channel;
+	return _midiController->assignedChannel;
 }
 
 void Synthesizer::setMidiChannel(unsigned char channel)
 {
-	Configuration::get().midi_channel = channel;
+	_midiController->assignedChannel = channel;
 	if (channel != kMidiChannel_Any) {
 		// A reset is required when switching to a new channel since we will
 		// not receive the note off events for currently held notes.

--- a/src/drivers/ALSAMidiDriver.cpp
+++ b/src/drivers/ALSAMidiDriver.cpp
@@ -23,6 +23,8 @@
 
 #ifdef WITH_ALSA
 
+#include "../Configuration.h"
+
 #define ALSA_PCM_OLD_HW_PARAMS_API
 #define ALSA_PCM_OLD_SW_PARAMS_API
 #include <alsa/asoundlib.h>
@@ -167,5 +169,5 @@ ALSAMidiDriver::~ALSAMidiDriver()
 
 MidiDriver* CreateAlsaMidiDriver(const char *client_name) { return new ALSAMidiDriver(client_name); }
 #else
-MidiDriver* CreateAlsaMidiDriver(const char *client_name) { return NULL; }
+MidiDriver* CreateAlsaMidiDriver(const char *client_name) { return nullptr; }
 #endif

--- a/src/drivers/MidiDriver.h
+++ b/src/drivers/MidiDriver.h
@@ -22,8 +22,6 @@
 #ifndef _MIDI_DRIVER_H
 #define _MIDI_DRIVER_H
 
-#include "../Configuration.h"
-
 class MidiDriver
 {
 public:

--- a/src/drivers/OSSMidiDriver.cpp
+++ b/src/drivers/OSSMidiDriver.cpp
@@ -23,6 +23,8 @@
 #include "config.h"
 #endif
 
+#include "../Configuration.h"
+
 #include <unistd.h>
 #include <sys/types.h>
 #include <sys/stat.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -359,8 +359,17 @@ int main( int argc, char *argv[] )
 	// errors now detected & reported in the GUI
 	out->init();
 
+	Preset::setIgnoredParameterNames(config.ignored_parameters);
+
 	s_synthesizer = new Synthesizer();
 	s_synthesizer->setSampleRate(config.sample_rate);
+	s_synthesizer->setMaxNumVoices(config.polyphony);
+	s_synthesizer->setMidiChannel(config.midi_channel);
+	s_synthesizer->setPitchBendRangeSemitones(config.pitch_bend_range);
+	if (config.current_tuning_file != "default") {
+		s_synthesizer->loadTuningScale(config.current_tuning_file.c_str());
+	}
+	s_synthesizer->loadBank(config.current_bank_file.c_str());
 	
 	amsynth_load_bank(config.current_bank_file.c_str());
 	amsynth_set_preset_number(initial_preset_no);


### PR DESCRIPTION
Stops settings from configuration file (represented by `Configuration`) being applied to plug-in instances.

Resolves #173