### PR TITLE
Fix PatriksBank02: 046

### DIFF
--- a/data/amsynth.lv2/PatriksBank02.bank.ttl
+++ b/data/amsynth.lv2/PatriksBank02.bank.ttl
@@ -5986,10 +5986,10 @@
         pset:value 1.000000
     ] .
 
-<http://code.google.com/p/amsynth/amsynth#PatriksBank02_046_"A"_voices>
+<http://code.google.com/p/amsynth/amsynth#PatriksBank02_046_A_voices>
     a pset:Preset ;
     lv2:appliesTo <http://code.google.com/p/amsynth/amsynth> ;
-    rdfs:label "PatriksBank02: 046: "A" voices" ;
+    rdfs:label 'PatriksBank02: 046: "A" voices' ;
     pset:bank <http://code.google.com/p/amsynth/amsynth#PatriksBank02> ;
     lv2:port [
         lv2:symbol "amp_attack" ;

--- a/data/amsynth.lv2/amsynth.ttl
+++ b/data/amsynth.lv2/amsynth.ttl
@@ -18681,10 +18681,10 @@
     rdfs:label "PatriksBank02: 045: Lullaby Voice" ;
     rdfs:seeAlso <PatriksBank02.bank.ttl> .
 
-<http://code.google.com/p/amsynth/amsynth#PatriksBank02_046_"A"_voices>
+<http://code.google.com/p/amsynth/amsynth#PatriksBank02_046_A_voices>
     a pset:Preset ;
     lv2:appliesTo <http://code.google.com/p/amsynth/amsynth> ;
-    rdfs:label "PatriksBank02: 046: "A" voices" ;
+    rdfs:label 'PatriksBank02: 046: "A" voices' ;
     rdfs:seeAlso <PatriksBank02.bank.ttl> .
 
 <http://code.google.com/p/amsynth/amsynth#PatriksBank02_047_Brass_Section>


### PR DESCRIPTION
data/amsynth.lv2/PatriksBank02.bank.ttl,data/amsynth.lv2/amsynth.ttl:
The URI for "PatriksBank02: 046" is not valid, as it contains literal
double quotes (").
The rdfs:label due to internal doube quotes is also invalid.
By removing the double quotes from the URI and single-quoting the
rdfs:label entries lv2lint is able to validate the files again.

Fixes #178