### PR TITLE
Fix LV2 preset generation for names containing ‘“‘

### DIFF
--- a/data/amsynth.lv2/PatriksBank02.bank.ttl
+++ b/data/amsynth.lv2/PatriksBank02.bank.ttl
@@ -5986,10 +5986,10 @@
         pset:value 1.000000
     ] .
 
-<http://code.google.com/p/amsynth/amsynth#PatriksBank02_046_A_voices>
+<http://code.google.com/p/amsynth/amsynth#PatriksBank02_046__A__voices>
     a pset:Preset ;
     lv2:appliesTo <http://code.google.com/p/amsynth/amsynth> ;
-    rdfs:label 'PatriksBank02: 046: "A" voices' ;
+    rdfs:label "PatriksBank02: 046: \"A\" voices" ;
     pset:bank <http://code.google.com/p/amsynth/amsynth#PatriksBank02> ;
     lv2:port [
         lv2:symbol "amp_attack" ;

--- a/data/amsynth.lv2/amsynth.ttl
+++ b/data/amsynth.lv2/amsynth.ttl
@@ -18681,10 +18681,10 @@
     rdfs:label "PatriksBank02: 045: Lullaby Voice" ;
     rdfs:seeAlso <PatriksBank02.bank.ttl> .
 
-<http://code.google.com/p/amsynth/amsynth#PatriksBank02_046_A_voices>
+<http://code.google.com/p/amsynth/amsynth#PatriksBank02_046__A__voices>
     a pset:Preset ;
     lv2:appliesTo <http://code.google.com/p/amsynth/amsynth> ;
-    rdfs:label 'PatriksBank02: 046: "A" voices' ;
+    rdfs:label "PatriksBank02: 046: \"A\" voices" ;
     rdfs:seeAlso <PatriksBank02.bank.ttl> .
 
 <http://code.google.com/p/amsynth/amsynth#PatriksBank02_047_Brass_Section>

--- a/utils/lv2_presets.py
+++ b/utils/lv2_presets.py
@@ -54,8 +54,8 @@ def lv2_bank_write(filepath, bank_name, presets):
 ''' % (bank_uri, bank_name))
 
 		for i, preset in enumerate(presets):
-			preset_uri = bank_name + '_%03d_' % i + re.sub(r'\s', '_', preset['name'])
-			label = '%s: %03d: %s' % (bank_name, i, preset['name'])
+			preset_uri = bank_name + '_%03d_' % i + re.sub(r'[\s"]', '_', preset['name'])
+			label = '%s: %03d: %s' % (bank_name, i, preset['name'].replace('"', r'\"'))
 			# When banks are more widely supported, we should switch to this:
 			#label = '%03d: %s' % (i, preset['name'])
 			print(lv2_preset_header.format(preset_uri=preset_uri, label=label))


### PR DESCRIPTION
A more permanent fix for lv2lint validation failure #178