### PR TITLE
Fix bad character in lv2 turtle file

### DIFF
--- a/data/amsynth.lv2/amsynth.ttl
+++ b/data/amsynth.lv2/amsynth.ttl
@@ -20117,7 +20117,7 @@
     rdfs:label "PatriksBank04: 027: Wood Seasons" ;
     rdfs:seeAlso <PatriksBank04.bank.ttl> .
 
-<http://code.google.com/p/amsynth/amsynth#PatriksBank04_028_Bell->Organ>
+<http://code.google.com/p/amsynth/amsynth#PatriksBank04_028_Bell_Organ>
     a pset:Preset ;
     lv2:appliesTo <http://code.google.com/p/amsynth/amsynth> ;
     rdfs:label "PatriksBank04: 028: Bell->Organ" ;


### PR DESCRIPTION
data/amsynth.lv2/amsynth.ttl:
Replace a `->` with a `_` as the former does not produce a valid word.

Fixes #199