### PR TITLE
Refactor parameter declarations

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -9,5 +9,5 @@ src/GUI/MainWindow.cpp
 src/GUI/MIDILearnDialog.cpp
 src/GUI/PresetControllerView.cpp
 src/main.cpp
-src/Preset.cpp
+src/Parameter.cpp
 src/PresetController.cpp

--- a/po/de.po
+++ b/po/de.po
@@ -3,12 +3,12 @@
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
-#: ../src/GUI/ConfigDialog.cpp:98
+#: ../src/GUI/ConfigDialog.cpp:103
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-17 18:26+0100\n"
+"POT-Creation-Date: 2022-06-05 13:30+0100\n"
 "PO-Revision-Date: 2017-01-18 21:05+0100\n"
 "Last-Translator: Peter Körner <18427@gmx.net>\n"
 "Language-Team: \n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../data/amsynth.appdata.xml.in.h:1 ../src/GUI/MainMenu.cpp:655
+#: ../data/amsynth.appdata.xml.in.h:1 ../src/GUI/MainMenu.cpp:666
 msgid "Analog Modelling SYNTHesizer"
 msgstr "Virtuell-analoger Synthesizer"
 
@@ -147,61 +147,70 @@ msgstr "ALSA-Audiogerät"
 msgid "Sample Rate"
 msgstr "Samplerate"
 
+#: ../src/GUI/ConfigDialog.cpp:98
+msgid "JACK"
+msgstr ""
+
 #: ../src/GUI/ConfigDialog.cpp:99
+msgid "Automatically connect to system outputs"
+msgstr ""
+
+#: ../src/GUI/ConfigDialog.cpp:104
 msgid "Changes take effect after restarting amsynth"
 msgstr "Änderungen werden nach einem Neustart von amsynth wirksam"
 
 #: ../src/GUI/editor_menus.cpp:74
-msgid "MIDI Learn..."
-msgstr "MIDI-Lernen..."
+#, fuzzy
+msgid "Assign MIDI Controller..."
+msgstr "MIDI-Controller"
 
 #: ../src/GUI/editor_menus.cpp:78
 msgid "Ignore Preset Value"
 msgstr "Preset-Wert ignorieren"
 
-#: ../src/GUI/editor_menus.cpp:115 ../src/GUI/PresetControllerView.cpp:238
+#: ../src/GUI/editor_menus.cpp:113 ../src/GUI/PresetControllerView.cpp:233
 msgid "F"
 msgstr "F"
 
-#: ../src/GUI/editor_menus.cpp:115 ../src/GUI/PresetControllerView.cpp:238
+#: ../src/GUI/editor_menus.cpp:113 ../src/GUI/PresetControllerView.cpp:233
 msgid "U"
 msgstr "U"
 
-#: ../src/GUI/editor_menus.cpp:165
+#: ../src/GUI/editor_menus.cpp:163
 #, fuzzy
 msgid "Preset"
 msgstr "_Preset"
 
-#: ../src/GUI/editor_menus.cpp:167
+#: ../src/GUI/editor_menus.cpp:165
 msgid "Tuning"
 msgstr ""
 
-#: ../src/GUI/editor_menus.cpp:169 ../src/GUI/MainMenu.cpp:143
+#: ../src/GUI/editor_menus.cpp:167 ../src/GUI/MainMenu.cpp:143
 msgid "Open Alternate Tuning File..."
 msgstr "Lade andere Stimmung..."
 
-#: ../src/GUI/editor_menus.cpp:170 ../src/GUI/MainMenu.cpp:144
+#: ../src/GUI/editor_menus.cpp:168 ../src/GUI/MainMenu.cpp:144
 msgid "Open Alternate Keyboard Map..."
 msgstr "Lade andere Keyboard-Map..."
 
-#: ../src/GUI/editor_menus.cpp:171 ../src/GUI/MainMenu.cpp:145
+#: ../src/GUI/editor_menus.cpp:169 ../src/GUI/MainMenu.cpp:145
 #: ../src/GUI/MainMenu.cpp:229
 msgid "Reset All Tuning Settings to Default"
 msgstr "Setze alle Stimmungseinstellungen auf den Standard zurück"
 
-#: ../src/GUI/editor_menus.cpp:203 ../src/GUI/MainMenu.cpp:198
+#: ../src/GUI/editor_menus.cpp:201 ../src/GUI/MainMenu.cpp:198
 msgid "Open Scala (.scl) alternate tuning file"
 msgstr "Lade andere Open-Scala-Stimmungsdatei (.scl)"
 
-#: ../src/GUI/editor_menus.cpp:204 ../src/GUI/MainMenu.cpp:198
+#: ../src/GUI/editor_menus.cpp:202 ../src/GUI/MainMenu.cpp:198
 msgid "Scala scale files"
 msgstr "Scala-Tonleiterdatei"
 
-#: ../src/GUI/editor_menus.cpp:210 ../src/GUI/MainMenu.cpp:202
+#: ../src/GUI/editor_menus.cpp:208 ../src/GUI/MainMenu.cpp:202
 msgid "Failed to load new tuning."
 msgstr "Laden der neuen Stimmung ist gescheitert."
 
-#: ../src/GUI/editor_menus.cpp:211 ../src/GUI/MainMenu.cpp:203
+#: ../src/GUI/editor_menus.cpp:209 ../src/GUI/MainMenu.cpp:203
 #, fuzzy
 msgid ""
 "Reading the tuning file failed for some reason.\n"
@@ -210,19 +219,19 @@ msgstr ""
 "Laden der Stimmungsdatei ist fehlgeschlagen. Hat die Datei das richtige "
 "Format?"
 
-#: ../src/GUI/editor_menus.cpp:224 ../src/GUI/MainMenu.cpp:211
+#: ../src/GUI/editor_menus.cpp:222 ../src/GUI/MainMenu.cpp:211
 msgid "Open alternate keyboard map (Scala .kbm format)"
 msgstr "Lade andere Keyboard-Map (Scala-.kbm-Format)"
 
-#: ../src/GUI/editor_menus.cpp:225 ../src/GUI/MainMenu.cpp:211
+#: ../src/GUI/editor_menus.cpp:223 ../src/GUI/MainMenu.cpp:211
 msgid "Scala keyboard map files"
 msgstr "Scala-Keyboard-Map-Dateien"
 
-#: ../src/GUI/editor_menus.cpp:231 ../src/GUI/MainMenu.cpp:215
+#: ../src/GUI/editor_menus.cpp:229 ../src/GUI/MainMenu.cpp:215
 msgid "Failed to load new keyboard map."
 msgstr "Laden der neuen Keyboard-Map ist fehlgeschlagen."
 
-#: ../src/GUI/editor_menus.cpp:232 ../src/GUI/MainMenu.cpp:216
+#: ../src/GUI/editor_menus.cpp:230 ../src/GUI/MainMenu.cpp:216
 #, fuzzy
 msgid ""
 "Reading the keyboard map file failed for some reason.\n"
@@ -358,94 +367,94 @@ msgid "Audio & MIDI..."
 msgstr "Audio & MIDI..."
 
 #. @translators: This is an application name and its abbreviation
-#: ../src/GUI/MainMenu.cpp:527
+#: ../src/GUI/MainMenu.cpp:538
 msgid "Virtual Keyboard (vkeybd)"
 msgstr "Virtual Keyboard (vkeybd)"
 
 #. @translators: This is an application name and its abbreviation
-#: ../src/GUI/MainMenu.cpp:532
+#: ../src/GUI/MainMenu.cpp:543
 msgid "Virtual MIDI Piano Keyboard (VMPK)"
 msgstr "Virtual MIDI Piano Keyboard (VMPK)"
 
-#: ../src/GUI/MainMenu.cpp:536
+#: ../src/GUI/MainMenu.cpp:547
 msgid "Virtual Keyboards"
 msgstr "Virtuelle Keyboards"
 
-#: ../src/GUI/MainMenu.cpp:554
+#: ../src/GUI/MainMenu.cpp:565
 msgid "MIDI (ALSA) connections"
 msgstr "MIDI-Verbindungen (ALSA)"
 
-#: ../src/GUI/MainMenu.cpp:574
+#: ../src/GUI/MainMenu.cpp:585
 msgid "Audio (JACK) connections"
 msgstr "Audioverbindungen (JACK)"
 
-#: ../src/GUI/MainMenu.cpp:619
+#: ../src/GUI/MainMenu.cpp:630
 msgid "About"
 msgstr "Über"
 
-#: ../src/GUI/MainMenu.cpp:620
+#: ../src/GUI/MainMenu.cpp:631
 msgid "Report a Bug"
 msgstr "Einen Fehler melden"
 
-#: ../src/GUI/MainMenu.cpp:621
+#: ../src/GUI/MainMenu.cpp:632
 msgid "Online Documentation"
 msgstr "Online-Dokumentation"
 
-#: ../src/GUI/MainMenu.cpp:657
+#: ../src/GUI/MainMenu.cpp:668
 #, fuzzy
-msgid "Copyright © 2002 - 2017 Nick Dowell and contributors"
+msgid "Copyright © 2002 - 2020 Nick Dowell and contributors"
 msgstr "Copyright © 2002 - 2016 Nick Dowell und Mitwirkende"
 
-#: ../src/GUI/MainMenu.cpp:665
+#: ../src/GUI/MainMenu.cpp:676
 msgid "Could not show link"
 msgstr "Link kann nicht angezeigt werden"
 
-#: ../src/GUI/MainMenu.cpp:676
+#: ../src/GUI/MainMenu.cpp:687
 msgid "_File"
 msgstr "_Datei"
 
-#: ../src/GUI/MainMenu.cpp:677
+#: ../src/GUI/MainMenu.cpp:688
 msgid "_Preset"
 msgstr "_Preset"
 
-#: ../src/GUI/MainMenu.cpp:678
+#: ../src/GUI/MainMenu.cpp:689
 msgid "_Config"
 msgstr "_Konfiguration"
 
-#: ../src/GUI/MainMenu.cpp:679
+#: ../src/GUI/MainMenu.cpp:690
 msgid "_Utils"
 msgstr "_Werkzeuge"
 
-#: ../src/GUI/MainMenu.cpp:680
+#: ../src/GUI/MainMenu.cpp:691
 msgid "_Help"
 msgstr "_Hilfe"
 
-#: ../src/GUI/MainWindow.cpp:68
+#: ../src/GUI/MainWindow.cpp:74
 #, c-format
 msgid "Audio: %s @ %d  MIDI: %s"
 msgstr "Audio: %s @ %d  MIDI: %s"
 
-#: ../src/GUI/MainWindow.cpp:182
+#: ../src/GUI/MainWindow.cpp:190
 #, fuzzy
 msgid "Save changes before closing?"
 msgstr "Sollen die Änderungen vor dem Beenden gespeichert werden?"
 
-#: ../src/GUI/MainWindow.cpp:184
+#: ../src/GUI/MainWindow.cpp:192
 msgid "Close _Without Saving"
 msgstr "_Beenden ohne zu speichern"
 
-#: ../src/GUI/MainWindow.cpp:188
+#: ../src/GUI/MainWindow.cpp:196
 msgid ""
 "If you don't save, changes to the current preset will be permanently lost."
 msgstr ""
 "Ohne zu speichern gehen die Änderungen am aktuellen Preset dauerhaft "
 "verloren."
 
-#: ../src/GUI/MainWindow.cpp:265 ../src/GUI/MainWindow.cpp:272
+#: ../src/GUI/MainWindow.cpp:300 ../src/GUI/MainWindow.cpp:307
 msgid "amsynth configuration error"
 msgstr "amsynth-Konfigurationsfehler"
 
-#: ../src/GUI/MainWindow.cpp:266
+#: ../src/GUI/MainWindow.cpp:301
 msgid ""
 "amsynth could not initialise the selected audio device.\n"
 "\n"
@@ -455,7 +464,7 @@ msgstr ""
 "\n"
 "Bitte die Konfiguration prüfen und neu starten"
 
-#: ../src/GUI/MainWindow.cpp:273
+#: ../src/GUI/MainWindow.cpp:308
 msgid ""
 "amsynth could not initialise the selected MIDI device.\n"
 "\n"
@@ -465,149 +474,138 @@ msgstr ""
 "\n"
 "Bitte die Konfiguration prüfen und neu starten"
 
-#: ../src/GUI/MIDILearnDialog.cpp:37
-msgid "MIDI Learn"
-msgstr "MIDI-Lernen"
+#: ../src/GUI/MIDILearnDialog.cpp:34
+#, fuzzy
+msgid "MIDI Controller Assignment"
+msgstr "MIDI-Controller"
 
-#: ../src/GUI/MIDILearnDialog.cpp:47
+#: ../src/GUI/MIDILearnDialog.cpp:44
 msgid "None"
 msgstr "Keiner"
 
-#: ../src/GUI/MIDILearnDialog.cpp:52
+#: ../src/GUI/MIDILearnDialog.cpp:48
+msgid "Select automatically"
+msgstr ""
+
+#: ../src/GUI/MIDILearnDialog.cpp:49
+msgid "Automatically select MIDI Controller when a CC message is received"
+msgstr ""
+
+#: ../src/GUI/MIDILearnDialog.cpp:57
 msgid "Synth Parameter:"
 msgstr "Synth-Parameter:"
 
-#: ../src/GUI/MIDILearnDialog.cpp:54
+#: ../src/GUI/MIDILearnDialog.cpp:59
 msgid "MIDI Controller"
 msgstr "MIDI-Controller"
 
-#: ../src/GUI/PresetControllerView.cpp:122
+#: ../src/GUI/PresetControllerView.cpp:121
 msgid "Save"
 msgstr "Speichern"
 
-#: ../src/GUI/PresetControllerView.cpp:130
+#: ../src/GUI/PresetControllerView.cpp:129
 msgid "Audition"
 msgstr "Hörprobe"
 
-#: ../src/GUI/PresetControllerView.cpp:145
+#: ../src/GUI/PresetControllerView.cpp:144
 msgid "Panic"
 msgstr "Panik"
 
-#: ../src/main.cpp:87
+#: ../src/main.cpp:93
 msgid "Failed to set SCHED_FIFO\n"
 msgstr "Setzen von SCHED_FIFO gescheitert\n"
 
-#: ../src/main.cpp:106
-#, c-format
-msgid "error reading source file %s\n"
-msgstr "Fehler beim Lesen der Quelldatei %s\n"
-
-#: ../src/main.cpp:111
-#, c-format
-msgid "error creating destination file %s\n"
-msgstr "Fehler beim Anlegen der Zieldatei %s\n"
-
-#: ../src/main.cpp:146
-#, c-format
-msgid "installing configuration file to %s\n"
-msgstr "Installiere Konfigurationsdatei nach %s\n"
-
-#: ../src/main.cpp:151
-#, c-format
-msgid "installing default sound bank to %s\n"
-msgstr "Installiere Standard-Soundbank nach %s\n"
-
-#: ../src/main.cpp:211
+#: ../src/main.cpp:157
 msgid "JACK init failed: "
 msgstr "JACK-Initialisierung gescheitert: "
 
-#: ../src/main.cpp:237
+#: ../src/main.cpp:183
 msgid "error: could not open ALSA MIDI interface"
 msgstr "Fehler: Kann ALSA-MIDI-Interface nicht öffnen"
 
-#: ../src/main.cpp:244
+#: ../src/main.cpp:190
 msgid "error: could not open OSS MIDI interface"
 msgstr "Fehler: Kann OSS-MIDI-Interface nicht öffnen"
 
-#: ../src/main.cpp:253
+#: ../src/main.cpp:199
 msgid "error: could not open any MIDI interface"
 msgstr "Fehler: Kein MIDI-Interface kann geöffnet werden"
 
-#: ../src/main.cpp:316
+#: ../src/main.cpp:266
 msgid "usage: "
 msgstr "Verwendung: "
 
-#: ../src/main.cpp:316
+#: ../src/main.cpp:266
 msgid " [options]"
 msgstr " [Optionen]"
 
-#: ../src/main.cpp:318
+#: ../src/main.cpp:268
 msgid ""
 "Any options given here override those in the config file ($HOME/.amSynthrc)"
 msgstr ""
 "Alle hier angegebenen Optionen setzen diejenigen aus der Konfigurationsdatei "
 "($HOME/.amSynthrc) außer Kraft"
 
-#: ../src/main.cpp:320
+#: ../src/main.cpp:270
 msgid "OPTIONS:"
 msgstr "OPTIONEN:"
 
-#: ../src/main.cpp:322
+#: ../src/main.cpp:272
 msgid "\t-h          show this usage message"
 msgstr "\t-h          zeigt diese Verwendungsbeschreibung"
 
-#: ../src/main.cpp:323
+#: ../src/main.cpp:273
 msgid "\t-v          show version information"
 msgstr "\t-v          zeigt Versionsinformationen"
 
-#: ../src/main.cpp:324
+#: ../src/main.cpp:274
 msgid "\t-x          run in headless mode (without GUI)"
 msgstr "\t-x          führt amsynth ohne grafische Oberfläche aus"
 
-#: ../src/main.cpp:326
+#: ../src/main.cpp:276
 msgid "\t-b <file>   use <file> as the bank to store presets"
 msgstr "\t-b <Datei>  nutzt <Datei> als Bank zum Speichern von Presets"
 
-#: ../src/main.cpp:327
+#: ../src/main.cpp:277
 msgid "\t-t <file>   use <file> as a tuning file"
 msgstr "\t-t <Datei>  nutzt <Datei> als Stimmungsdatei"
 
-#: ../src/main.cpp:329
+#: ../src/main.cpp:279
 msgid ""
 "\t-a <string> set the sound output driver to use [alsa/oss/auto(default)]"
 msgstr ""
 "\t-a <string> setzt den Audio-Ausgabe-Treiber als [alsa/oss/auto(Standard)]"
 
-#: ../src/main.cpp:330
+#: ../src/main.cpp:280
 msgid "\t-r <int>    set the sampling rate to use"
 msgstr "\t-r <int>    setzt die zu verwendende Samplerate"
 
-#: ../src/main.cpp:331
+#: ../src/main.cpp:281
 msgid "\t-m <string> set the MIDI driver to use [alsa/oss/auto(default)]"
 msgstr ""
 "\t-m <string> setzt den zu verwendenden MIDI-Treiber [alsa/oss/"
 "auto(Standard)]"
 
-#: ../src/main.cpp:332
+#: ../src/main.cpp:282
 msgid "\t-c <int>    set the MIDI channel to respond to (default=all)"
 msgstr ""
 "\t-c <int>    setzt den MIDI-Kanal, auf den reagiert werden soll "
 "(Standard=alle)"
 
-#: ../src/main.cpp:333
+#: ../src/main.cpp:283
 msgid "\t-p <int>    set the polyphony (maximum active voices)"
 msgstr ""
 "\t-p <int>    setzt die Polyphonie (maximale Anzahl der aktiven Stimmen)"
 
-#: ../src/main.cpp:335
+#: ../src/main.cpp:285
 msgid "\t-n <name>   specify the JACK client name to use"
 msgstr "\t-n <Name>   legt den JACK-Client-Namen fest"
 
-#: ../src/main.cpp:336
+#: ../src/main.cpp:286
 msgid "\t--jack_autoconnect[=<true|false>]"
 msgstr "\t--jack_autoconnect[=<true|false>]"
 
-#: ../src/main.cpp:337
+#: ../src/main.cpp:287
 msgid ""
 "\t            automatically connect jack audio ports to hardware I/O ports. "
 "(Default: true)"
@@ -615,139 +613,165 @@ msgstr ""
 "\t            legt die automatische Verbindung von JACK-Audio-Ports mit "
 "Hardware-I/O-Ports fest. (Standard: true)"
 
-#: ../src/main.cpp:411
+#: ../src/main.cpp:289
+msgid "\t--force-device-scale-factor <scale>"
+msgstr ""
+
+#: ../src/main.cpp:290
+msgid "\t            override the default scaling factor for the control panel"
+msgstr ""
+
+#: ../src/main.cpp:356
 msgid "Fatal Error: open_audio() returned NULL.\n"
 msgstr "Fataler Fehler: open_audio() hat NULL zurückgegeben.\n"
 
-#: ../src/main.cpp:458
+#: ../src/main.cpp:418
 #, c-format
 msgid "amsynth running in headless mode, press ctrl-c to exit\n"
 msgstr "amsynth läuft ohne grafische Oberfläche, Strg+C zum Beenden\n"
 
-#: ../src/main.cpp:463
+#: ../src/main.cpp:423
 #, c-format
 msgid "shutting down...\n"
 msgstr "Beende...\n"
 
-#: ../src/main.cpp:470
+#: ../src/main.cpp:430
 msgid " audio buffer underruns occurred\n"
 msgstr " Audio Buffer Underruns sind aufgetreten\n"
 
-#: ../src/main.cpp:564
+#: ../src/main.cpp:524
 msgid "error: could not load tuning file "
 msgstr "Fehler: Konnte Stimmungsdatei nicht laden: "
 
-#: ../src/main.cpp:626
+#: ../src/main.cpp:586
 #, c-format
 msgid "user time: %f\t\tsystem time: %f\n"
 msgstr "Benutzerzeit: %f\t\tSystemzeit: %f\n"
 
-#: ../src/main.cpp:627
+#: ../src/main.cpp:587
 #, c-format
 msgid "performance index: %f\n"
 msgstr "Leistungsindex: %f\n"
 
-#: ../src/Preset.cpp:324 ../src/Preset.cpp:334
+#: ../src/Parameter.cpp:284 ../src/Parameter.cpp:294
 msgid "sine"
 msgstr "Sinus"
 
 # "Rechteck" von "Rechteckschwingung" <-> "square wave"
-#: ../src/Preset.cpp:325
+#: ../src/Parameter.cpp:285
 msgid "square / pulse"
 msgstr "Rechteck / Puls"
 
-#: ../src/Preset.cpp:326
+#: ../src/Parameter.cpp:286
 msgid "triangle / saw"
 msgstr "Dreieck / Sägezahn"
 
-#: ../src/Preset.cpp:327
+#: ../src/Parameter.cpp:287
 msgid "white noise"
 msgstr "Weißes Rauschen"
 
-#: ../src/Preset.cpp:328 ../src/Preset.cpp:338
+#: ../src/Parameter.cpp:288 ../src/Parameter.cpp:298
 msgid "noise + sample & hold"
 msgstr "Rauschen + Sample & Hold"
 
 # "Rechteck" von "Rechteckschwingung" <-> "square wave"
-#: ../src/Preset.cpp:335
+#: ../src/Parameter.cpp:295
 msgid "square"
 msgstr "Rechteck"
 
-#: ../src/Preset.cpp:336
+#: ../src/Parameter.cpp:296
 msgid "triangle"
 msgstr "Dreieck"
 
-#: ../src/Preset.cpp:337
+#: ../src/Parameter.cpp:297
 msgid "noise"
 msgstr "Rauschen"
 
-#: ../src/Preset.cpp:339
+#: ../src/Parameter.cpp:299
 msgid "sawtooth (up)"
 msgstr "Sägezahn (aufwärts)"
 
-#: ../src/Preset.cpp:340
+#: ../src/Parameter.cpp:300
 msgid "sawtooth (down)"
 msgstr "Sägezahn (abwärts)"
 
-#: ../src/Preset.cpp:346
+#: ../src/Parameter.cpp:306
 msgid "poly"
 msgstr "Poly"
 
-#: ../src/Preset.cpp:347
+#: ../src/Parameter.cpp:307
 msgid "mono"
 msgstr "Mono"
 
-#: ../src/Preset.cpp:348 ../src/Preset.cpp:380
+#: ../src/Parameter.cpp:308 ../src/Parameter.cpp:340
 msgid "legato"
 msgstr "Legato"
 
-#: ../src/Preset.cpp:354
+#: ../src/Parameter.cpp:314
 msgid "low pass"
 msgstr "Tiefpass"
 
-#: ../src/Preset.cpp:355
+#: ../src/Parameter.cpp:315
 msgid "high pass"
 msgstr "Hochpass"
 
-#: ../src/Preset.cpp:356
+#: ../src/Parameter.cpp:316
 msgid "band pass"
 msgstr "Bandpass"
 
-#: ../src/Preset.cpp:357
+#: ../src/Parameter.cpp:317
 msgid "notch"
 msgstr "Kerbfilter"
 
-#: ../src/Preset.cpp:358
+#: ../src/Parameter.cpp:318
 msgid "bypass"
 msgstr "Umgehen"
 
-#: ../src/Preset.cpp:364
+#: ../src/Parameter.cpp:324
 msgid "12 dB / octave"
 msgstr "12 db/Oktave"
 
-#: ../src/Preset.cpp:365
+#: ../src/Parameter.cpp:325
 msgid "24 dB / octave"
 msgstr "24 db/Oktave"
 
-#: ../src/Preset.cpp:371
+#: ../src/Parameter.cpp:331
 msgid "osc 1+2"
 msgstr "osc 1+2"
 
-#: ../src/Preset.cpp:372
+#: ../src/Parameter.cpp:332
 msgid "osc 1"
 msgstr "osc 1"
 
-#: ../src/Preset.cpp:373
+#: ../src/Parameter.cpp:333
 msgid "osc 2"
 msgstr "osc 2"
 
-#: ../src/Preset.cpp:379
+#: ../src/Parameter.cpp:339
 msgid "always"
 msgstr "Immer"
 
-#: ../src/PresetController.cpp:415
+#: ../src/PresetController.cpp:401
 msgid "User bank"
 msgstr "Benutzerbank"
+
+#~ msgid "MIDI Learn..."
+#~ msgstr "MIDI-Lernen..."
+
+#~ msgid "MIDI Learn"
+#~ msgstr "MIDI-Lernen"
+
+#~ msgid "error reading source file %s\n"
+#~ msgstr "Fehler beim Lesen der Quelldatei %s\n"
+
+#~ msgid "error creating destination file %s\n"
+#~ msgstr "Fehler beim Anlegen der Zieldatei %s\n"
+
+#~ msgid "installing configuration file to %s\n"
+#~ msgstr "Installiere Konfigurationsdatei nach %s\n"
+
+#~ msgid "installing default sound bank to %s\n"
+#~ msgstr "Installiere Standard-Soundbank nach %s\n"
 
 #, fuzzy
 #~ msgid "lv2 plugin"

--- a/po/fr.po
+++ b/po/fr.po
@@ -4,12 +4,12 @@
 # This file is distributed under the same license as the amsynth package.
 # Olivier Humbert <trebmuh@tuxfamily.org>, 2016-2017.
 #
-#: ../src/GUI/ConfigDialog.cpp:98
+#: ../src/GUI/ConfigDialog.cpp:103
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-07-17 18:26+0100\n"
+"POT-Creation-Date: 2022-06-05 13:30+0100\n"
 "PO-Revision-Date: 2017-11-25 00:30+0100\n"
 "Last-Translator: Olivier Humbert <trebmuh@tuxfamily.org>\n"
 "Language-Team: \n"
@@ -18,7 +18,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../data/amsynth.appdata.xml.in.h:1 ../src/GUI/MainMenu.cpp:655
+#: ../data/amsynth.appdata.xml.in.h:1 ../src/GUI/MainMenu.cpp:666
 msgid "Analog Modelling SYNTHesizer"
 msgstr "Synthétiseur modelant de l'analogique"
 
@@ -147,60 +147,69 @@ msgstr "Périphérique audio ALSA"
 msgid "Sample Rate"
 msgstr "Taux d'échantillonnage"
 
+#: ../src/GUI/ConfigDialog.cpp:98
+msgid "JACK"
+msgstr ""
+
 #: ../src/GUI/ConfigDialog.cpp:99
+msgid "Automatically connect to system outputs"
+msgstr ""
+
+#: ../src/GUI/ConfigDialog.cpp:104
 msgid "Changes take effect after restarting amsynth"
 msgstr "Les modifications prendront effet après avoir redémarré amsynth"
 
 #: ../src/GUI/editor_menus.cpp:74
-msgid "MIDI Learn..."
-msgstr "Apprentissage MIDI..."
+#, fuzzy
+msgid "Assign MIDI Controller..."
+msgstr "Contrôleur MIDI"
 
 #: ../src/GUI/editor_menus.cpp:78
 msgid "Ignore Preset Value"
 msgstr "Ignorer la valeur de pré-réglage"
 
-#: ../src/GUI/editor_menus.cpp:115 ../src/GUI/PresetControllerView.cpp:238
+#: ../src/GUI/editor_menus.cpp:113 ../src/GUI/PresetControllerView.cpp:233
 msgid "F"
 msgstr "F"
 
-#: ../src/GUI/editor_menus.cpp:115 ../src/GUI/PresetControllerView.cpp:238
+#: ../src/GUI/editor_menus.cpp:113 ../src/GUI/PresetControllerView.cpp:233
 msgid "U"
 msgstr "U"
 
-#: ../src/GUI/editor_menus.cpp:165
+#: ../src/GUI/editor_menus.cpp:163
 msgid "Preset"
 msgstr "Pré-réglage"
 
-#: ../src/GUI/editor_menus.cpp:167
+#: ../src/GUI/editor_menus.cpp:165
 msgid "Tuning"
 msgstr "Accordage"
 
-#: ../src/GUI/editor_menus.cpp:169 ../src/GUI/MainMenu.cpp:143
+#: ../src/GUI/editor_menus.cpp:167 ../src/GUI/MainMenu.cpp:143
 msgid "Open Alternate Tuning File..."
 msgstr "Ouvrir un fichier d'accordage alternatif..."
 
-#: ../src/GUI/editor_menus.cpp:170 ../src/GUI/MainMenu.cpp:144
+#: ../src/GUI/editor_menus.cpp:168 ../src/GUI/MainMenu.cpp:144
 msgid "Open Alternate Keyboard Map..."
 msgstr "Ouvrir une carte de clavier alternative..."
 
-#: ../src/GUI/editor_menus.cpp:171 ../src/GUI/MainMenu.cpp:145
+#: ../src/GUI/editor_menus.cpp:169 ../src/GUI/MainMenu.cpp:145
 #: ../src/GUI/MainMenu.cpp:229
 msgid "Reset All Tuning Settings to Default"
 msgstr "Réinitialiser tous les paramètres d'accordage par défaut"
 
-#: ../src/GUI/editor_menus.cpp:203 ../src/GUI/MainMenu.cpp:198
+#: ../src/GUI/editor_menus.cpp:201 ../src/GUI/MainMenu.cpp:198
 msgid "Open Scala (.scl) alternate tuning file"
 msgstr "Ouvrir un fichier d'accordage alternatif Scala (.scl)"
 
-#: ../src/GUI/editor_menus.cpp:204 ../src/GUI/MainMenu.cpp:198
+#: ../src/GUI/editor_menus.cpp:202 ../src/GUI/MainMenu.cpp:198
 msgid "Scala scale files"
 msgstr "fichiers de gamme Scala"
 
-#: ../src/GUI/editor_menus.cpp:210 ../src/GUI/MainMenu.cpp:202
+#: ../src/GUI/editor_menus.cpp:208 ../src/GUI/MainMenu.cpp:202
 msgid "Failed to load new tuning."
 msgstr "Échec du chargement d'un nouvel accordage."
 
-#: ../src/GUI/editor_menus.cpp:211 ../src/GUI/MainMenu.cpp:203
+#: ../src/GUI/editor_menus.cpp:209 ../src/GUI/MainMenu.cpp:203
 msgid ""
 "Reading the tuning file failed for some reason.\n"
 "Make sure your file has the correct format and try again."
@@ -208,19 +217,19 @@ msgstr ""
 "La lecture du fichier d'accordage a échouée pour une raison quelconque.\n"
 "Assurez-vous que votre fichier possède le format correct et ré-essayez."
 
-#: ../src/GUI/editor_menus.cpp:224 ../src/GUI/MainMenu.cpp:211
+#: ../src/GUI/editor_menus.cpp:222 ../src/GUI/MainMenu.cpp:211
 msgid "Open alternate keyboard map (Scala .kbm format)"
 msgstr "Ouvrir une carte de clavier alternative (format Scala .kbm)"
 
-#: ../src/GUI/editor_menus.cpp:225 ../src/GUI/MainMenu.cpp:211
+#: ../src/GUI/editor_menus.cpp:223 ../src/GUI/MainMenu.cpp:211
 msgid "Scala keyboard map files"
 msgstr "fichiers de carte de clavier Scala"
 
-#: ../src/GUI/editor_menus.cpp:231 ../src/GUI/MainMenu.cpp:215
+#: ../src/GUI/editor_menus.cpp:229 ../src/GUI/MainMenu.cpp:215
 msgid "Failed to load new keyboard map."
 msgstr "Échec du chargement d'une nouvelle carte de clavier."
 
-#: ../src/GUI/editor_menus.cpp:232 ../src/GUI/MainMenu.cpp:216
+#: ../src/GUI/editor_menus.cpp:230 ../src/GUI/MainMenu.cpp:216
 msgid ""
 "Reading the keyboard map file failed for some reason.\n"
 "Make sure your file has the correct format and try again."
@@ -356,92 +365,93 @@ msgid "Audio & MIDI..."
 msgstr "Audio & MIDI..."
 
 #. @translators: This is an application name and its abbreviation
-#: ../src/GUI/MainMenu.cpp:527
+#: ../src/GUI/MainMenu.cpp:538
 msgid "Virtual Keyboard (vkeybd)"
 msgstr "Clavier virtuel (vkeybd)"
 
 #. @translators: This is an application name and its abbreviation
-#: ../src/GUI/MainMenu.cpp:532
+#: ../src/GUI/MainMenu.cpp:543
 msgid "Virtual MIDI Piano Keyboard (VMPK)"
 msgstr "Clavier virtuel de piano MIDI (VMPK)"
 
-#: ../src/GUI/MainMenu.cpp:536
+#: ../src/GUI/MainMenu.cpp:547
 msgid "Virtual Keyboards"
 msgstr "Claviers virtuels"
 
-#: ../src/GUI/MainMenu.cpp:554
+#: ../src/GUI/MainMenu.cpp:565
 msgid "MIDI (ALSA) connections"
 msgstr "Connexions MIDI (ALSA)"
 
-#: ../src/GUI/MainMenu.cpp:574
+#: ../src/GUI/MainMenu.cpp:585
 msgid "Audio (JACK) connections"
 msgstr "Connexions audio (JACK)"
 
-#: ../src/GUI/MainMenu.cpp:619
+#: ../src/GUI/MainMenu.cpp:630
 msgid "About"
 msgstr "À propos"
 
-#: ../src/GUI/MainMenu.cpp:620
+#: ../src/GUI/MainMenu.cpp:631
 msgid "Report a Bug"
 msgstr "Remonter un bogue"
 
-#: ../src/GUI/MainMenu.cpp:621
+#: ../src/GUI/MainMenu.cpp:632
 msgid "Online Documentation"
 msgstr "Documentation en ligne"
 
-#: ../src/GUI/MainMenu.cpp:657
-msgid "Copyright © 2002 - 2017 Nick Dowell and contributors"
+#: ../src/GUI/MainMenu.cpp:668
+#, fuzzy
+msgid "Copyright © 2002 - 2020 Nick Dowell and contributors"
 msgstr "Copyright © 2002 - 2017 Nick Dowell et contributeurs"
 
-#: ../src/GUI/MainMenu.cpp:665
+#: ../src/GUI/MainMenu.cpp:676
 msgid "Could not show link"
 msgstr "Ne peut pas montrer le lien"
 
-#: ../src/GUI/MainMenu.cpp:676
+#: ../src/GUI/MainMenu.cpp:687
 msgid "_File"
 msgstr "_Fichier"
 
-#: ../src/GUI/MainMenu.cpp:677
+#: ../src/GUI/MainMenu.cpp:688
 msgid "_Preset"
 msgstr "_Pré-réglage"
 
-#: ../src/GUI/MainMenu.cpp:678
+#: ../src/GUI/MainMenu.cpp:689
 msgid "_Config"
 msgstr "_Configuration"
 
-#: ../src/GUI/MainMenu.cpp:679
+#: ../src/GUI/MainMenu.cpp:690
 msgid "_Utils"
 msgstr "_Utilitaires"
 
-#: ../src/GUI/MainMenu.cpp:680
+#: ../src/GUI/MainMenu.cpp:691
 msgid "_Help"
 msgstr "_Aide"
 
-#: ../src/GUI/MainWindow.cpp:68
+#: ../src/GUI/MainWindow.cpp:74
 #, c-format
 msgid "Audio: %s @ %d  MIDI: %s"
 msgstr "Audio : %s @ %d  MIDI : %s"
 
-#: ../src/GUI/MainWindow.cpp:182
+#: ../src/GUI/MainWindow.cpp:190
 msgid "Save changes before closing?"
 msgstr "Sauvegarder les modifications avant de quitter ?"
 
-#: ../src/GUI/MainWindow.cpp:184
+#: ../src/GUI/MainWindow.cpp:192
 msgid "Close _Without Saving"
 msgstr "Fermer _sans sauvegarder"
 
-#: ../src/GUI/MainWindow.cpp:188
+#: ../src/GUI/MainWindow.cpp:196
 msgid ""
 "If you don't save, changes to the current preset will be permanently lost."
 msgstr ""
 "Si vous ne sauvegardez pas, les modifications des pré-réglages actuels "
 "seront perdues définitivement."
 
-#: ../src/GUI/MainWindow.cpp:265 ../src/GUI/MainWindow.cpp:272
+#: ../src/GUI/MainWindow.cpp:300 ../src/GUI/MainWindow.cpp:307
 msgid "amsynth configuration error"
 msgstr "erreur de configuration d'amsynth"
 
-#: ../src/GUI/MainWindow.cpp:266
+#: ../src/GUI/MainWindow.cpp:301
 msgid ""
 "amsynth could not initialise the selected audio device.\n"
 "\n"
@@ -451,7 +461,7 @@ msgstr ""
 "\n"
 "Veuillez revoir la configuration et redémarrer"
 
-#: ../src/GUI/MainWindow.cpp:273
+#: ../src/GUI/MainWindow.cpp:308
 msgid ""
 "amsynth could not initialise the selected MIDI device.\n"
 "\n"
@@ -461,151 +471,140 @@ msgstr ""
 "\n"
 "Veuillez revoir la configuration et redémarrer"
 
-#: ../src/GUI/MIDILearnDialog.cpp:37
-msgid "MIDI Learn"
-msgstr "Apprentissage MIDI"
+#: ../src/GUI/MIDILearnDialog.cpp:34
+#, fuzzy
+msgid "MIDI Controller Assignment"
+msgstr "Contrôleur MIDI"
 
-#: ../src/GUI/MIDILearnDialog.cpp:47
+#: ../src/GUI/MIDILearnDialog.cpp:44
 msgid "None"
 msgstr "Aucun"
 
-#: ../src/GUI/MIDILearnDialog.cpp:52
+#: ../src/GUI/MIDILearnDialog.cpp:48
+msgid "Select automatically"
+msgstr ""
+
+#: ../src/GUI/MIDILearnDialog.cpp:49
+msgid "Automatically select MIDI Controller when a CC message is received"
+msgstr ""
+
+#: ../src/GUI/MIDILearnDialog.cpp:57
 msgid "Synth Parameter:"
 msgstr "Paramètre du synthétiseur :"
 
-#: ../src/GUI/MIDILearnDialog.cpp:54
+#: ../src/GUI/MIDILearnDialog.cpp:59
 msgid "MIDI Controller"
 msgstr "Contrôleur MIDI"
 
-#: ../src/GUI/PresetControllerView.cpp:122
+#: ../src/GUI/PresetControllerView.cpp:121
 msgid "Save"
 msgstr "Sauvegarder"
 
-#: ../src/GUI/PresetControllerView.cpp:130
+#: ../src/GUI/PresetControllerView.cpp:129
 msgid "Audition"
 msgstr "Audition"
 
-#: ../src/GUI/PresetControllerView.cpp:145
+#: ../src/GUI/PresetControllerView.cpp:144
 msgid "Panic"
 msgstr "Panique"
 
-#: ../src/main.cpp:87
+#: ../src/main.cpp:93
 msgid "Failed to set SCHED_FIFO\n"
 msgstr "Échec de paramètrage SCHED_FIFO\n"
 
-#: ../src/main.cpp:106
-#, c-format
-msgid "error reading source file %s\n"
-msgstr "erreur de la lecture du fichier source %s\n"
-
-#: ../src/main.cpp:111
-#, c-format
-msgid "error creating destination file %s\n"
-msgstr "erreur de la création du fichier de destination %s\n"
-
-#: ../src/main.cpp:146
-#, c-format
-msgid "installing configuration file to %s\n"
-msgstr "installation du fichier de configuration dans %s\n"
-
-#: ../src/main.cpp:151
-#, c-format
-msgid "installing default sound bank to %s\n"
-msgstr "installation de la banque de son par défaut dans %s\n"
-
-#: ../src/main.cpp:211
+#: ../src/main.cpp:157
 msgid "JACK init failed: "
 msgstr "échec de l'initialisation de JACK : "
 
-#: ../src/main.cpp:237
+#: ../src/main.cpp:183
 msgid "error: could not open ALSA MIDI interface"
 msgstr "erreur : n'a pas pu ouvrir l'interface MIDI ALSA"
 
-#: ../src/main.cpp:244
+#: ../src/main.cpp:190
 msgid "error: could not open OSS MIDI interface"
 msgstr "erreur : n'a pas pu ouvrir l'interface MIDI OSS"
 
-#: ../src/main.cpp:253
+#: ../src/main.cpp:199
 msgid "error: could not open any MIDI interface"
 msgstr "erreur : n'a pu ouvrir aucune interface MIDI"
 
-#: ../src/main.cpp:316
+#: ../src/main.cpp:266
 msgid "usage: "
 msgstr "utilisation : "
 
-#: ../src/main.cpp:316
+#: ../src/main.cpp:266
 msgid " [options]"
 msgstr " [options]"
 
-#: ../src/main.cpp:318
+#: ../src/main.cpp:268
 msgid ""
 "Any options given here override those in the config file ($HOME/.amSynthrc)"
 msgstr ""
 "Toute option donnée ici écrase celle du fichier de configuration ($HOME/."
 "amSynthrc)"
 
-#: ../src/main.cpp:320
+#: ../src/main.cpp:270
 msgid "OPTIONS:"
 msgstr "OPTIONS :"
 
-#: ../src/main.cpp:322
+#: ../src/main.cpp:272
 msgid "\t-h          show this usage message"
 msgstr "\t-h          affiche ce message d'aide"
 
-#: ../src/main.cpp:323
+#: ../src/main.cpp:273
 msgid "\t-v          show version information"
 msgstr "\t-v          affiche les informations de version"
 
-#: ../src/main.cpp:324
+#: ../src/main.cpp:274
 msgid "\t-x          run in headless mode (without GUI)"
 msgstr "\t-x          lancer en mode sans-interface-graphique"
 
-#: ../src/main.cpp:326
+#: ../src/main.cpp:276
 msgid "\t-b <file>   use <file> as the bank to store presets"
 msgstr ""
 "\t-b <nom_de_fichier>   utilise <nom_de_fichier> en tant que banque pour "
 "sauvegarder les pré-réglages"
 
-#: ../src/main.cpp:327
+#: ../src/main.cpp:277
 msgid "\t-t <file>   use <file> as a tuning file"
 msgstr ""
 "\t-t <nom_de_fichier>   utilise <nom_de_fichier> en tant que fichier "
 "d'accordage"
 
-#: ../src/main.cpp:329
+#: ../src/main.cpp:279
 msgid ""
 "\t-a <string> set the sound output driver to use [alsa/oss/auto(default)]"
 msgstr ""
 "\t-a <chaîne_de_caractères> paramètre le pilote de sortie son à utiliser "
 "[alsa/oss/auto(défaut)]"
 
-#: ../src/main.cpp:330
+#: ../src/main.cpp:280
 msgid "\t-r <int>    set the sampling rate to use"
 msgstr "\t-r <entier>    paramètre le taux d'échantillonnage à utiliser"
 
-#: ../src/main.cpp:331
+#: ../src/main.cpp:281
 msgid "\t-m <string> set the MIDI driver to use [alsa/oss/auto(default)]"
 msgstr ""
 "\t-m <chaîne_de_caractères> paramètre le pilote MIDI à utiliser [alsa/oss/"
 "auto(défaut)]"
 
-#: ../src/main.cpp:332
+#: ../src/main.cpp:282
 msgid "\t-c <int>    set the MIDI channel to respond to (default=all)"
 msgstr "\t-c <entier>    paramètre le canal MIDI auquel répondre (défaut=tous)"
 
-#: ../src/main.cpp:333
+#: ../src/main.cpp:283
 msgid "\t-p <int>    set the polyphony (maximum active voices)"
 msgstr "\t-p <entier>    paramètre la polyphonie (voix actives maximum)"
 
-#: ../src/main.cpp:335
+#: ../src/main.cpp:285
 msgid "\t-n <name>   specify the JACK client name to use"
 msgstr "\t-n <nom>   spécifie le nom de client JACK à utiliser"
 
-#: ../src/main.cpp:336
+#: ../src/main.cpp:286
 msgid "\t--jack_autoconnect[=<true|false>]"
 msgstr "\t--jack_autoconnect[=<true|false>]"
 
-#: ../src/main.cpp:337
+#: ../src/main.cpp:287
 msgid ""
 "\t            automatically connect jack audio ports to hardware I/O ports. "
 "(Default: true)"
@@ -613,139 +612,165 @@ msgstr ""
 "\t            connecter automatiquement les ports audio jack aux ports "
 "d'entrées/sorties matériels. (par défaut : true)"
 
-#: ../src/main.cpp:411
+#: ../src/main.cpp:289
+msgid "\t--force-device-scale-factor <scale>"
+msgstr ""
+
+#: ../src/main.cpp:290
+msgid "\t            override the default scaling factor for the control panel"
+msgstr ""
+
+#: ../src/main.cpp:356
 msgid "Fatal Error: open_audio() returned NULL.\n"
 msgstr "Erreur fatale : open_audio() a retourné NULL.\n"
 
-#: ../src/main.cpp:458
+#: ../src/main.cpp:418
 #, c-format
 msgid "amsynth running in headless mode, press ctrl-c to exit\n"
 msgstr ""
 "amsynth est lancé en mode sans-interface-graphique, pressez ctrl-c pour "
 "quitter\n"
 
-#: ../src/main.cpp:463
+#: ../src/main.cpp:423
 #, c-format
 msgid "shutting down...\n"
 msgstr "en train de quitter...\n"
 
-#: ../src/main.cpp:470
+#: ../src/main.cpp:430
 msgid " audio buffer underruns occurred\n"
 msgstr " décrochage audio du tampon audio est arrivé\n"
 
-#: ../src/main.cpp:564
+#: ../src/main.cpp:524
 msgid "error: could not load tuning file "
 msgstr "erreur : échec du chargement du fichier d'accordage "
 
-#: ../src/main.cpp:626
+#: ../src/main.cpp:586
 #, c-format
 msgid "user time: %f\t\tsystem time: %f\n"
 msgstr "temps utilisateur : %f\t\ttemps système : %f\n"
 
-#: ../src/main.cpp:627
+#: ../src/main.cpp:587
 #, c-format
 msgid "performance index: %f\n"
 msgstr "index de performance : %f\n"
 
-#: ../src/Preset.cpp:324 ../src/Preset.cpp:334
+#: ../src/Parameter.cpp:284 ../src/Parameter.cpp:294
 msgid "sine"
 msgstr "sinusoïde"
 
-#: ../src/Preset.cpp:325
+#: ../src/Parameter.cpp:285
 msgid "square / pulse"
 msgstr "carré / pulsation"
 
-#: ../src/Preset.cpp:326
+#: ../src/Parameter.cpp:286
 msgid "triangle / saw"
 msgstr "triangle / dent-de-scie"
 
-#: ../src/Preset.cpp:327
+#: ../src/Parameter.cpp:287
 msgid "white noise"
 msgstr "bruit blanc"
 
-#: ../src/Preset.cpp:328 ../src/Preset.cpp:338
+#: ../src/Parameter.cpp:288 ../src/Parameter.cpp:298
 msgid "noise + sample & hold"
 msgstr "bruit + échantillon & maintien"
 
-#: ../src/Preset.cpp:335
+#: ../src/Parameter.cpp:295
 msgid "square"
 msgstr "carré"
 
-#: ../src/Preset.cpp:336
+#: ../src/Parameter.cpp:296
 msgid "triangle"
 msgstr "triangle"
 
-#: ../src/Preset.cpp:337
+#: ../src/Parameter.cpp:297
 msgid "noise"
 msgstr "bruit"
 
-#: ../src/Preset.cpp:339
+#: ../src/Parameter.cpp:299
 msgid "sawtooth (up)"
 msgstr "dent-de-scie (vers le haut)"
 
-#: ../src/Preset.cpp:340
+#: ../src/Parameter.cpp:300
 msgid "sawtooth (down)"
 msgstr "dent-de-scie (vers le bas)"
 
-#: ../src/Preset.cpp:346
+#: ../src/Parameter.cpp:306
 msgid "poly"
 msgstr "poly"
 
-#: ../src/Preset.cpp:347
+#: ../src/Parameter.cpp:307
 msgid "mono"
 msgstr "mono"
 
-#: ../src/Preset.cpp:348 ../src/Preset.cpp:380
+#: ../src/Parameter.cpp:308 ../src/Parameter.cpp:340
 msgid "legato"
 msgstr "legato"
 
-#: ../src/Preset.cpp:354
+#: ../src/Parameter.cpp:314
 msgid "low pass"
 msgstr "passe-bas"
 
-#: ../src/Preset.cpp:355
+#: ../src/Parameter.cpp:315
 msgid "high pass"
 msgstr "passe-haut"
 
-#: ../src/Preset.cpp:356
+#: ../src/Parameter.cpp:316
 msgid "band pass"
 msgstr "passe-bande"
 
-#: ../src/Preset.cpp:357
+#: ../src/Parameter.cpp:317
 msgid "notch"
 msgstr "à encoche"
 
-#: ../src/Preset.cpp:358
+#: ../src/Parameter.cpp:318
 msgid "bypass"
 msgstr "court-circuit"
 
-#: ../src/Preset.cpp:364
+#: ../src/Parameter.cpp:324
 msgid "12 dB / octave"
 msgstr "12 dB / octave"
 
-#: ../src/Preset.cpp:365
+#: ../src/Parameter.cpp:325
 msgid "24 dB / octave"
 msgstr "24 dB / octave"
 
-#: ../src/Preset.cpp:371
+#: ../src/Parameter.cpp:331
 msgid "osc 1+2"
 msgstr "osc 1+2"
 
-#: ../src/Preset.cpp:372
+#: ../src/Parameter.cpp:332
 msgid "osc 1"
 msgstr "osc 1"
 
-#: ../src/Preset.cpp:373
+#: ../src/Parameter.cpp:333
 msgid "osc 2"
 msgstr "osc 2"
 
-#: ../src/Preset.cpp:379
+#: ../src/Parameter.cpp:339
 msgid "always"
 msgstr "toujours"
 
-#: ../src/PresetController.cpp:415
+#: ../src/PresetController.cpp:401
 msgid "User bank"
 msgstr "Banque utilisateur"
+
+#~ msgid "MIDI Learn..."
+#~ msgstr "Apprentissage MIDI..."
+
+#~ msgid "MIDI Learn"
+#~ msgstr "Apprentissage MIDI"
+
+#~ msgid "error reading source file %s\n"
+#~ msgstr "erreur de la lecture du fichier source %s\n"
+
+#~ msgid "error creating destination file %s\n"
+#~ msgstr "erreur de la création du fichier de destination %s\n"
+
+#~ msgid "installing configuration file to %s\n"
+#~ msgstr "installation du fichier de configuration dans %s\n"
+
+#~ msgid "installing default sound bank to %s\n"
+#~ msgstr "installation de la banque de son par défaut dans %s\n"
 
 #~ msgid "lv2 plugin"
 #~ msgstr "greffon LV2"

--- a/src/Parameter.cpp
+++ b/src/Parameter.cpp
@@ -1,7 +1,7 @@
 /*
  *  Parameter.h
  *
- *  Copyright (c) 2001-2020 Nick Dowell
+ *  Copyright (c) 2001-2022 Nick Dowell
  *
  *  This file is part of amsynth.
  *
@@ -23,34 +23,70 @@
 
 #include "VoiceBoard/Synth--.h"
 
-#include <algorithm>
 #include <cassert>
-#include <cmath>
 #include <sstream>
 
-Parameter::Parameter(const std::string &name, Param id, float value, float min, float max, float inc, Law law, float base, float offset, const std::string &label)
-:	_paramId	(id)
-,	_name		(name)
-,	_label		(label)
-,	_law		(law)
-,	_default	(value)
-,	_value		(m::nan)
-,	_min		(min)
-,	_max		(max)
-,	_step		(inc)
-,	_controlValue(m::nan)
-,	_base		(base)
-,	_offset		(offset)
-{
-	assert(min < max);
-	setValue (value);
-}
+#if defined _MSC_VER // does not support Designated Initializers
+#define SPEC(id, name, def, min, max, step, law, base, offset, label)        { name, def, min, max,  step, law, base, offset, label }
+#else
+#define SPEC(id, name, def, min, max, step, law, base, offset, label) [id] = { name, def, min, max,  step, law, base, offset, label }
+#endif
+
+static const ParameterSpec ParameterSpecs[] = { //                            def,    min,    max,  step,       law,                         base,  offset,     label
+	SPEC(kAmsynthParameter_AmpEnvAttack,            "amp_attack",            0.0f,   0.0f,   2.5f,  0.0f,       kParameterLaw_Power,         3.0f,  0.0005f,    "s"  ),
+	SPEC(kAmsynthParameter_AmpEnvDecay,             "amp_decay",             0.0f,   0.0f,   2.5f,  0.0f,       kParameterLaw_Power,         3.0f,  0.0005f,    "s"  ),
+	SPEC(kAmsynthParameter_AmpEnvSustain,           "amp_sustain",           1.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_AmpEnvRelease,           "amp_release",           0.0f,   0.0f,   2.5f,  0.0f,       kParameterLaw_Power,         3.0f,  0.0005f,    "s"  ),
+	SPEC(kAmsynthParameter_Oscillator1Waveform,     "osc1_waveform",         2.0f,   0.0f,   4.0f,  1.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_FilterEnvAttack,         "filter_attack",         0.0f,   0.0f,   2.5f,  0.0f,       kParameterLaw_Power,         3.0f,  0.0005f,    "s"  ),
+	SPEC(kAmsynthParameter_FilterEnvDecay,          "filter_decay",          0.0f,   0.0f,   2.5f,  0.0f,       kParameterLaw_Power,         3.0f,  0.0005f,    "s"  ),
+	SPEC(kAmsynthParameter_FilterEnvSustain,        "filter_sustain",        1.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_FilterEnvRelease,        "filter_release",        0.0f,   0.0f,   2.5f,  0.0f,       kParameterLaw_Power,         3.0f,  0.0005f,    "s"  ),
+	SPEC(kAmsynthParameter_FilterResonance,         "filter_resonance",      0.0f,   0.0f,   0.97f, 0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_FilterEnvAmount,         "filter_env_amount",     0.0f, -16.0f,  16.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_FilterCutoff,            "filter_cutoff",         1.5f,  -0.5f,   1.5f,  0.0f,       kParameterLaw_Exponential,  16.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_Oscillator2Detune,       "osc2_detune",           0.0f,  -1.0f,   1.0f,  0.0f,       kParameterLaw_Exponential,   1.25f, 0.0f,       ""   ),
+	SPEC(kAmsynthParameter_Oscillator2Waveform,     "osc2_waveform",         2.0f,   0.0f,   4.0f,  1.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_MasterVolume,            "master_vol",            0.67f,  0.0f,   1.0f,  0.0f,       kParameterLaw_Power,         2.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_LFOFreq,                 "lfo_freq",              0.0f,   0.0f,   7.5f,  0.0f,       kParameterLaw_Power,         2.0f,  0.0f,       "Hz" ),
+	SPEC(kAmsynthParameter_LFOWaveform,             "lfo_waveform",          0.0f,   0.0f,   6.0f,  1.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_Oscillator2Octave,       "osc2_range",            0.0f,  -3.0f,   4.0f,  1.0f,       kParameterLaw_Exponential,   2.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_OscillatorMix,           "osc_mix",               0.0f,  -1.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_LFOToOscillators,        "freq_mod_amount",       0.0f,   0.0f, 1.25992105f, 0.0f,   kParameterLaw_Power,         3.0f, -1.0f,       ""   ),
+	SPEC(kAmsynthParameter_LFOToFilterCutoff,       "filter_mod_amount",    -1.0f,  -1.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_LFOToAmp,                "amp_mod_amount",       -1.0f,  -1.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_OscillatorMixRingMod,    "osc_mix_mode",          0.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_Oscillator1Pulsewidth,   "osc1_pulsewidth",       1.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_Oscillator2Pulsewidth,   "osc2_pulsewidth",       1.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_ReverbRoomsize,          "reverb_roomsize",       0.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_ReverbDamp,              "reverb_damp",           0.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_ReverbWet,               "reverb_wet",            0.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_ReverbWidth,             "reverb_width",          1.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_AmpDistortion,           "distortion_crunch",     0.0f,   0.0f,   0.9f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_Oscillator2Sync,         "osc2_sync",             0.0f,   0.0f,   1.0f,  1.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_PortamentoTime,          "portamento_time",       0.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_KeyboardMode,            "keyboard_mode",         0.0f,   0.0f,   2.0f,  1.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_Oscillator2Pitch,        "osc2_pitch",            0.0f, -12.0f,  12.0f,  1.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_FilterType,              "filter_type",           0.0f,   0.0f,   4.0f,  1.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_FilterSlope,             "filter_slope",          1.0f,   0.0f,   1.0f,  1.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_LFOOscillatorSelect,     "freq_mod_osc",          0.0f,   0.0f,   2.0f,  1.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_FilterKeyTrackAmount,    "filter_kbd_track",      1.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_FilterKeyVelocityAmount, "filter_vel_sens",       1.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_AmpVelocityAmount,       "amp_vel_sens",          1.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+	SPEC(kAmsynthParameter_PortamentoMode,          "portamento_mode",       0.0f,   0.0f,   1.0f,  0.0f,       kParameterLaw_Linear,        1.0f,  0.0f,       ""   ),
+};
+
+Parameter::Parameter(Param paramId)
+:	_paramId	(paramId)
+,	_spec		(ParameterSpecs[paramId])
+,	_value		(_spec.def)
+{}
 
 void
 Parameter::addUpdateListener(UpdateListener *listener)
 {
 	_listeners.insert(listener);
-	listener->UpdateParameter(_paramId, _controlValue);
+	listener->UpdateParameter(_paramId, getControlValue());
 }
 
 void
@@ -62,11 +98,13 @@ Parameter::removeUpdateListener(UpdateListener *listener)
 void
 Parameter::setValue(float value)
 {
-	float newValue = std::min(std::max(value, _min), _max);
+	if (value == _value) return;
+	
+	float newValue = std::min(std::max(value, _spec.min), _spec.max);
 
-	if (_step > 0.f) {
-		newValue = _min + roundf((newValue - _min) / _step) * _step;
-		assert(::fmodf(newValue - _min, _step) == 0);
+	if (_spec.step > 0.f) {
+		newValue = _spec.min + roundf((newValue - _spec.min) / _spec.step) * _spec.step;
+		assert(::fmodf(newValue - _spec.min, _spec.step) == 0);
 	}
 
 	if (_value == newValue) // warning: -ffast-math causes this comparison to fail
@@ -74,20 +112,24 @@ Parameter::setValue(float value)
 
 	_value = newValue;
 
-	switch (_law) {
-		case Law::kLinear:
-			_controlValue = _offset + _base * _value;
-			break;
-		case Law::kExponential:
-			_controlValue = _offset + ::pow( (float)_base, _value );
-			break;
-		case Law::kPower:
-			_controlValue = _offset + ::pow( _value, (float)_base );
-			break;
-	}
-
+	float cv = getControlValue();
 	for (auto &listener : _listeners) {
-		listener->UpdateParameter(_paramId, _controlValue);
+		listener->UpdateParameter(_paramId, cv);
+	}
+}
+
+float
+Parameter::getControlValue() const
+{
+	switch (_spec.law) {
+		case kParameterLaw_Linear:
+			return _spec.offset + _spec.base * _value;
+		case kParameterLaw_Exponential:
+			return _spec.offset + ::pow((float)_spec.base, _value);
+		case kParameterLaw_Power:
+			return _spec.offset + ::pow(_value, (float)_spec.base);
+		default:
+			abort();
 	}
 }
 
@@ -108,7 +150,7 @@ const std::string
 Parameter::getStringValue() const
 {
 	std::ostringstream stream;
-	stream << _controlValue;
+	stream << getControlValue();
 	return stream.str();
 }
 

--- a/src/Parameter.h
+++ b/src/Parameter.h
@@ -28,6 +28,24 @@
 #include <set>
 #include <string>
 
+enum ParameterLaw {
+	kParameterLaw_Linear,		// offset + base * value
+	kParameterLaw_Exponential,	// offset + base ^ value
+	kParameterLaw_Power			// offset + value ^ base
+};
+
+struct ParameterSpec {
+	const char name[20];
+	float def;
+	float min;
+	float max;
+	float step;
+	ParameterLaw law;
+	float base;
+	float offset;
+	const char label[4];
+};
+
 /**
  * @brief a Parameter holds a particular value for a slider, selector switch 
  * etc..
@@ -43,19 +61,8 @@
 class Parameter {
 public:
 
-	enum class Law {
-		kLinear,		// offset + base * value
-		kExponential,	// offset + base ^ value
-		kPower			// offset + value ^ base
-	};
+	Parameter(Param paramId);
 
-					Parameter		(const std::string &name = "unused", Param id = kAmsynthParameterCount,
-									 float value = 0.0, float min = 0.0, float max = 1.0, float inc = 0.0,
-									 Law law = Law::kLinear, float base = 1.0, float offset = 0.0,
-									 const std::string &label = "");
-
-	// The raw value of this parameter. Objects in the signal generation 
-	// path should not use this method, but getControlValue() instead.
 	float			getValue		() const { return _value; }
 	void			setValue		(float value);
 
@@ -69,11 +76,11 @@ public:
 
 	// The control value for this parameter.
 	// The control value is what the synthesis will use to get its values.
-	inline float	getControlValue	() const { return _controlValue; }
+	float			getControlValue		() const;
 
 	const std::string getStringValue	() const;
 
-	const std::string getName			() const { return _name; }
+	const std::string getName			() const { return _spec.name; }
 
 	Param			getId				() const { return _paramId; }
 
@@ -82,28 +89,27 @@ public:
 	void			addUpdateListener (UpdateListener *ul);
 	void			removeUpdateListener (UpdateListener *ul);
 
-	float			getDefault		() const { return _default; }
+	float			getDefault		() const { return _spec.def; }
 
 	// min/max values apply for calls to setValue() not ControlValue
-	float			getMin			() const { return _min; }
-	float			getMax			() const { return _max; }
+	float			getMin			() const { return _spec.min; }
+	float			getMax			() const { return _spec.max; }
 
 	// @return the increment value
-	float			getStep			() const { return _step; }
+	float			getStep			() const { return _spec.step; }
 	// @returns The number of discrete steps allowable in this Parameter.
-	int				getSteps		() const { return _step > 0.f ? (int) ((_max - _min) / _step) : 0; }
+	int				getSteps		() const { return _spec.step > 0.f ? (int) ((_spec.max - _spec.min) / _spec.step) : 0; }
 
 	// Set this parameter to a random value (in it's allowable range)
 	void			randomise		();
 
 	// The label assocaited with this Parameter. (e.g. "seconds")
-	const std::string getLabel		() const { return _label; }
+	const std::string getLabel		() const { return _spec.label; }
 
-private:
+// private:
 	Param							_paramId;
-	std::string						_name, _label;
-	Law								_law;
-	float							_default, _value, _min, _max, _step, _controlValue, _base, _offset;
+	const ParameterSpec &			_spec;
+	float							_value;
 	std::set<UpdateListener *>		_listeners;
 };
 

--- a/src/Preset.cpp
+++ b/src/Preset.cpp
@@ -129,7 +129,7 @@ Preset::toString(std::stringstream &stream)
 {
 	stream << "amSynth1.0preset" << std::endl;
 	stream << "<preset> " << "<name> " << getName() << std::endl;
-	for (unsigned n = 0; n < ParameterCount(); n++) {
+	for (int n = 0; n < kAmsynthParameterCount; n++) {
 		stream << "<parameter> " << getParameter(n).getName() << " " << getParameter(n).getValue() << std::endl;
 	}
 }
@@ -205,11 +205,11 @@ static const Preset &_get_preset()
 const char *parameter_name_from_index (int param_index)
 {
 	const Preset &_preset = _get_preset();
-	if (param_index < 0 || param_index >= (int)_preset.ParameterCount())
+	if (param_index < 0 || param_index >= (int)kAmsynthParameterCount)
 		return nullptr;
 	static std::vector<std::string> names;
 	if (names.empty())
-		names.resize(_preset.ParameterCount());
+		names.resize(kAmsynthParameterCount);
 	if (names[param_index].empty())
 		names[param_index] = _preset.getParameter(param_index).getName();
 	return names[param_index].c_str();
@@ -218,7 +218,7 @@ const char *parameter_name_from_index (int param_index)
 int parameter_index_from_name (const char *param_name)
 {
 	const Preset &_preset = _get_preset();
-	for (unsigned i=0; i<_preset.ParameterCount(); i++) {
+	for (int i = 0; i < kAmsynthParameterCount; i++) {
 		if (std::string(param_name) == _preset.getParameter(i).getName()) {
 			return i;
 		}

--- a/src/Preset.h
+++ b/src/Preset.h
@@ -22,8 +22,6 @@
 #ifndef _PRESET_H
 #define _PRESET_H
 
-#ifdef __cplusplus
-
 #include "Parameter.h"
 
 #include <sstream>
@@ -70,16 +68,3 @@ private:
 };
 
 #endif
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
-void get_parameter_properties(int parameter_index, double *minimum, double *maximum, double *default_value, double *step_size);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif
-

--- a/src/Preset.h
+++ b/src/Preset.h
@@ -1,7 +1,7 @@
 /*
  *  Preset.h
  *
- *  Copyright (c) 2001-2012 Nick Dowell
+ *  Copyright (c) 2001-2022 Nick Dowell
  *
  *  This file is part of amsynth.
  *
@@ -28,14 +28,17 @@
 
 #include <sstream>
 #include <string>
-#include <vector>
 
 
 class Preset
 {
 public:
 	Preset(const std::string name = "");
-					
+
+	Preset(const Preset& other);
+
+	~Preset();
+
 	Preset&			operator =		(const Preset& p);
 	
 	bool			isEqual			(const Preset &);
@@ -47,7 +50,7 @@ public:
 	Parameter&		getParameter	(const int no) { return mParameters[no]; };
 	const Parameter& getParameter	(const int no) const { return mParameters[no]; };
 	
-	size_t			ParameterCount	() const { return mParameters.size(); }
+	size_t			ParameterCount	() const { return kAmsynthParameterCount; }
 	
     void			randomise		();
     
@@ -65,8 +68,7 @@ public:
 
 private:
     std::string				mName;
-	std::vector<Parameter>	mParameters;
-	Parameter				nullparam{"null"};
+	Parameter				*mParameters;
 };
 
 #endif

--- a/src/Preset.h
+++ b/src/Preset.h
@@ -50,8 +50,6 @@ public:
 	Parameter&		getParameter	(const int no) { return mParameters[no]; };
 	const Parameter& getParameter	(const int no) const { return mParameters[no]; };
 	
-	size_t			ParameterCount	() const { return kAmsynthParameterCount; }
-	
     void			randomise		();
     
     void			AddListenerToAll(UpdateListener*);

--- a/src/PresetController.cpp
+++ b/src/PresetController.cpp
@@ -198,7 +198,7 @@ PresetController::savePresets		(const char *filename)
 			<< presets[i].getName() << endl;
 #endif
 			file << "<preset> " << "<name> " << presets[i].getName() << endl;
-			for (unsigned n = 0; n < presets[i].ParameterCount(); n++)
+			for (int n = 0; n < kAmsynthParameterCount; n++)
 			{
 #ifdef _DEBUG
 				cout << "PresetController::savePresets() :- parameter name="

--- a/src/controls.h
+++ b/src/controls.h
@@ -1,7 +1,7 @@
 /*
  *  controls.h
  *
- *  Copyright (c) 2001-2012 Nick Dowell
+ *  Copyright (c) 2001-2022 Nick Dowell
  *
  *  This file is part of amsynth.
  *
@@ -103,6 +103,8 @@ typedef enum {
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+void get_parameter_properties(int parameter_index, double *minimum, double *maximum, double *default_value, double *step_size);
 
 const char *parameter_name_from_index (int param_index);
 int parameter_index_from_name (const char *param_name);


### PR DESCRIPTION
Defines parameter limits & curves as a read-only struct array instead of being included in each `Parameter` object, reducing code size and runtime overhead.

Moves implementation of parameter related functions from `Preset.cpp` to `Parameter.cpp`.