### PR TITLE
Add information about -P option in the help menu

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -265,6 +265,7 @@ int main( int argc, char *argv[] )
 				     << _("	-x          run in headless mode (without GUI)") << endl
 				     << endl
 				     << _("	-b <file>   use <file> as the bank to store presets") << endl
+				     << _("	-P <int>    set preset number to use") << endl
 				     << _("	-t <file>   use <file> as a tuning file") << endl
 				     << endl
 				     << _("	-a <string> set the sound output driver to use [alsa/oss/auto(default)]") << endl


### PR DESCRIPTION
I tried to add the CLI option to specify which preset to use (which I asked about in issue #219 ), but realized it's already implemented, it's just not specified in the help menu.