### PR TITLE
Add common default MIDI controllers

### DIFF
--- a/src/core/midi.h
+++ b/src/core/midi.h
@@ -50,11 +50,11 @@ enum {
     MIDI_CC_SUSTAIN_PEDAL               = 0x40,
     MIDI_CC_PORTAMENTO                  = 0x41,
     MIDI_CC_SOSTENUTO                   = 0x42,
-    MIDI_CC_FILTER_RESONANCE            = 0x47,
-    MIDI_CC_AMP_ENV_RELEASE             = 0x48,
-    MIDI_CC_AMP_ENV_ATTACK              = 0x49,
-    MIDI_CC_FILTER_CUTOFF_FREQ          = 0x4A,
-    MIDI_CC_REVERB_LEVEL                = 0x5B,
+    MIDI_CC_SOUND_CONTROLLER_2          = 0x47, // default: Timbre/Harmonic Intensity
+    MIDI_CC_SOUND_CONTROLLER_3          = 0x48, // default: Release Time
+    MIDI_CC_SOUND_CONTROLLER_4          = 0x49, // default: Attack Time
+    MIDI_CC_SOUND_CONTROLLER_5          = 0x4A, // default: Brightness
+    MIDI_CC_EFFECTS_1_DEPTH             = 0x5B,
     MIDI_CC_NRPN_LSB                    = 0x62,
     MIDI_CC_NRPN_MSB                    = 0x63,
     MIDI_CC_RPN_LSB                     = 0x64,

--- a/src/core/midi.h
+++ b/src/core/midi.h
@@ -39,7 +39,9 @@ enum {
 enum {
     MIDI_CC_BANK_SELECT_MSB             = 0x00,
     MIDI_CC_MODULATION_WHEEL_MSB        = 0x01,
+    MIDI_CC_PORTAMENTO_TIME             = 0x05,
     MIDI_CC_DATA_ENTRY_MSB              = 0x06,
+    MIDI_CC_VOLUME                      = 0x07,
     MIDI_CC_PAN_MSB                     = 0x0A,
 
     MIDI_CC_BANK_SELECT_LSB             = 0x20,
@@ -48,6 +50,11 @@ enum {
     MIDI_CC_SUSTAIN_PEDAL               = 0x40,
     MIDI_CC_PORTAMENTO                  = 0x41,
     MIDI_CC_SOSTENUTO                   = 0x42,
+    MIDI_CC_FILTER_RESONANCE            = 0x47,
+    MIDI_CC_AMP_ENV_RELEASE             = 0x48,
+    MIDI_CC_AMP_ENV_ATTACK              = 0x49,
+    MIDI_CC_FILTER_CUTOFF_FREQ          = 0x4A,
+    MIDI_CC_REVERB_LEVEL                = 0x5B,
     MIDI_CC_NRPN_LSB                    = 0x62,
     MIDI_CC_NRPN_MSB                    = 0x63,
     MIDI_CC_RPN_LSB                     = 0x64,

--- a/src/core/synth/MidiController.cpp
+++ b/src/core/synth/MidiController.cpp
@@ -211,7 +211,16 @@ MidiController::controller_change(unsigned char cc, unsigned char value)
 		case MIDI_CC_MONO_MODE_ON:
 		case MIDI_CC_POLY_MODE_ON:
 			_handler->HandleMidiAllNotesOff();
+			break;
 		case MIDI_CC_MODULATION_WHEEL_MSB:
+		case MIDI_CC_PORTAMENTO_TIME:
+		case MIDI_CC_VOLUME:
+		case MIDI_CC_FILTER_RESONANCE:
+		case MIDI_CC_FILTER_CUTOFF_FREQ:
+		case MIDI_CC_AMP_ENV_ATTACK:
+		case MIDI_CC_AMP_ENV_RELEASE:
+		case MIDI_CC_REVERB_LEVEL:
+			/* Handled by controller map */
 		default:
 			break;
 	}
@@ -228,10 +237,22 @@ MidiController::clearControllerMap()
 		_param_to_cc_map[i] = -1;
 
 	// these are the defaults from /usr/share/amsynth/Controllersrc
-	_cc_to_param_map[1] = kAmsynthParameter_LFOToOscillators;
-	_param_to_cc_map[kAmsynthParameter_LFOToOscillators] = 1;
-	_cc_to_param_map[7] = kAmsynthParameter_MasterVolume;
-	_param_to_cc_map[kAmsynthParameter_MasterVolume] = 7;
+	_cc_to_param_map[MIDI_CC_MODULATION_WHEEL_MSB]       = kAmsynthParameter_LFOToOscillators;
+	_param_to_cc_map[kAmsynthParameter_LFOToOscillators] = MIDI_CC_MODULATION_WHEEL_MSB;
+	_cc_to_param_map[MIDI_CC_PORTAMENTO_TIME]            = kAmsynthParameter_PortamentoTime;
+	_param_to_cc_map[kAmsynthParameter_PortamentoTime]   = MIDI_CC_PORTAMENTO_TIME;
+	_cc_to_param_map[MIDI_CC_VOLUME]                     = kAmsynthParameter_MasterVolume;
+	_param_to_cc_map[kAmsynthParameter_MasterVolume]     = MIDI_CC_VOLUME;
+	_cc_to_param_map[MIDI_CC_FILTER_RESONANCE]           = kAmsynthParameter_FilterResonance;
+	_param_to_cc_map[kAmsynthParameter_FilterResonance]  = MIDI_CC_FILTER_RESONANCE;
+	_cc_to_param_map[MIDI_CC_FILTER_CUTOFF_FREQ]         = kAmsynthParameter_FilterCutoff;
+	_param_to_cc_map[kAmsynthParameter_FilterCutoff]     = MIDI_CC_FILTER_CUTOFF_FREQ;
+	_cc_to_param_map[MIDI_CC_AMP_ENV_ATTACK]             = kAmsynthParameter_AmpEnvAttack;
+	_param_to_cc_map[kAmsynthParameter_AmpEnvAttack]     = MIDI_CC_AMP_ENV_ATTACK;
+	_cc_to_param_map[MIDI_CC_AMP_ENV_RELEASE]            = kAmsynthParameter_AmpEnvRelease;
+	_param_to_cc_map[kAmsynthParameter_AmpEnvRelease]    = MIDI_CC_AMP_ENV_RELEASE;
+	_cc_to_param_map[MIDI_CC_REVERB_LEVEL]               = kAmsynthParameter_ReverbWet;
+	_param_to_cc_map[kAmsynthParameter_ReverbWet]        = MIDI_CC_REVERB_LEVEL;
 }
 
 void

--- a/src/core/synth/MidiController.cpp
+++ b/src/core/synth/MidiController.cpp
@@ -215,11 +215,11 @@ MidiController::controller_change(unsigned char cc, unsigned char value)
 		case MIDI_CC_MODULATION_WHEEL_MSB:
 		case MIDI_CC_PORTAMENTO_TIME:
 		case MIDI_CC_VOLUME:
-		case MIDI_CC_FILTER_RESONANCE:
-		case MIDI_CC_FILTER_CUTOFF_FREQ:
-		case MIDI_CC_AMP_ENV_ATTACK:
-		case MIDI_CC_AMP_ENV_RELEASE:
-		case MIDI_CC_REVERB_LEVEL:
+		case MIDI_CC_SOUND_CONTROLLER_2:
+		case MIDI_CC_SOUND_CONTROLLER_3:
+		case MIDI_CC_SOUND_CONTROLLER_4:
+		case MIDI_CC_SOUND_CONTROLLER_5:
+		case MIDI_CC_EFFECTS_1_DEPTH:
 			/* Handled by controller map */
 		default:
 			break;
@@ -243,16 +243,16 @@ MidiController::clearControllerMap()
 	_param_to_cc_map[kAmsynthParameter_PortamentoTime]   = MIDI_CC_PORTAMENTO_TIME;
 	_cc_to_param_map[MIDI_CC_VOLUME]                     = kAmsynthParameter_MasterVolume;
 	_param_to_cc_map[kAmsynthParameter_MasterVolume]     = MIDI_CC_VOLUME;
-	_cc_to_param_map[MIDI_CC_FILTER_RESONANCE]           = kAmsynthParameter_FilterResonance;
-	_param_to_cc_map[kAmsynthParameter_FilterResonance]  = MIDI_CC_FILTER_RESONANCE;
-	_cc_to_param_map[MIDI_CC_FILTER_CUTOFF_FREQ]         = kAmsynthParameter_FilterCutoff;
-	_param_to_cc_map[kAmsynthParameter_FilterCutoff]     = MIDI_CC_FILTER_CUTOFF_FREQ;
-	_cc_to_param_map[MIDI_CC_AMP_ENV_ATTACK]             = kAmsynthParameter_AmpEnvAttack;
-	_param_to_cc_map[kAmsynthParameter_AmpEnvAttack]     = MIDI_CC_AMP_ENV_ATTACK;
-	_cc_to_param_map[MIDI_CC_AMP_ENV_RELEASE]            = kAmsynthParameter_AmpEnvRelease;
-	_param_to_cc_map[kAmsynthParameter_AmpEnvRelease]    = MIDI_CC_AMP_ENV_RELEASE;
-	_cc_to_param_map[MIDI_CC_REVERB_LEVEL]               = kAmsynthParameter_ReverbWet;
-	_param_to_cc_map[kAmsynthParameter_ReverbWet]        = MIDI_CC_REVERB_LEVEL;
+	_cc_to_param_map[MIDI_CC_SOUND_CONTROLLER_2]         = kAmsynthParameter_FilterResonance;
+	_param_to_cc_map[kAmsynthParameter_FilterResonance]  = MIDI_CC_SOUND_CONTROLLER_2;
+	_cc_to_param_map[MIDI_CC_SOUND_CONTROLLER_3]         = kAmsynthParameter_AmpEnvRelease;
+	_param_to_cc_map[kAmsynthParameter_AmpEnvRelease]    = MIDI_CC_SOUND_CONTROLLER_3;
+	_cc_to_param_map[MIDI_CC_SOUND_CONTROLLER_4]         = kAmsynthParameter_AmpEnvAttack;
+	_param_to_cc_map[kAmsynthParameter_AmpEnvAttack]     = MIDI_CC_SOUND_CONTROLLER_4;
+	_cc_to_param_map[MIDI_CC_SOUND_CONTROLLER_5]         = kAmsynthParameter_FilterCutoff;
+	_param_to_cc_map[kAmsynthParameter_FilterCutoff]     = MIDI_CC_SOUND_CONTROLLER_5;
+	_cc_to_param_map[MIDI_CC_EFFECTS_1_DEPTH]            = kAmsynthParameter_ReverbWet;
+	_param_to_cc_map[kAmsynthParameter_ReverbWet]        = MIDI_CC_EFFECTS_1_DEPTH;
 }
 
 void


### PR DESCRIPTION
Added the following MIDI CC as default mapping:
```
MIDI CC 5  :  kAmsynthParameter_PortamentoTime
MIDI CC 71 :  kAmsynthParameter_FilterResonance
MIDI CC 72 :  kAmsynthParameter_AmpEnvRelease
MIDI CC 73 :  kAmsynthParameter_AmpEnvAttack
MIDI CC 74 :  kAmsynthParameter_FilterCutoff
MIDI CC 91 :  kAmsynthParameter_ReverbWet
```