### PR TITLE
add NSM keys to .desktop file

### DIFF
--- a/data/amsynth.desktop.in
+++ b/data/amsynth.desktop.in
@@ -11,4 +11,6 @@ Categories=AudioVideo;Audio;X-Synthesis;
 Keywords=music;synthesiser;softsynth;midi;jack;realtime;standalone;
 Exec=@prefix@/bin/amsynth
 Icon=amsynth
+X-NSM-Capable=true
+X-NSM-Exec=amsynth
 Terminal=false


### PR DESCRIPTION
This add NSM related desktop keys to the .desktop file, so NSM related tools can find applications with NSM support.

For NSM one can't use a path like @prefix@/bin/amsynth, it should be just amsynth as is done. 

X-NSM-Capable, is used to detect if the application has NSM support. It should ideally become false if the application is build without NSM support.
X-NSM-Exec, is the exec name of the application when used in NSM. It can't contain a path (not /usr/bin/ for example) or command line arguments like %f.